### PR TITLE
Multimodel reservoir modeling; update to Jutul/JutulDarcy 0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JutulDarcyAD"
 uuid = "41f0c4f5-9bdd-4ef1-8c3a-d454dff2d562"
 authors = ["Ziyi Yin <ziyi.yin@gatech.edu>"]
-version = "0.1.4"
+version = "0.2.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -17,8 +17,8 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 [compat]
 ChainRulesCore = "1"
 Flux = "0.12, 0.13"
-Jutul = "0.1.6, 0.2.1"
-JutulDarcy = "0.1.5, 0.2.0"
+Jutul = "0.2.1"
+JutulDarcy = "0.2.0"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -17,8 +17,8 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 [compat]
 ChainRulesCore = "1"
 Flux = "0.12, 0.13"
-Jutul = "0.1.6"
-JutulDarcy = "0.1.5"
+Jutul = "0.1.6, 0.2.1"
+JutulDarcy = "0.1.5, 0.2.0"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -17,8 +17,8 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 [compat]
 ChainRulesCore = "1"
 Flux = "0.12, 0.13"
-Jutul = "0.2.1"
-JutulDarcy = "0.2.0"
+Jutul = "0.2.2"
+JutulDarcy = "0.2.1"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JutulDarcyAD"
 uuid = "41f0c4f5-9bdd-4ef1-8c3a-d454dff2d562"
 authors = ["Ziyi Yin <ziyi.yin@gatech.edu>"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -9,10 +9,8 @@ Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 Jutul = "2b460a1a-8a2b-45b2-b125-b5c536396eb9"
 JutulDarcy = "82210473-ab04-4dce-b31b-11573c4f8e0a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-MultiComponentFlash = "35e5bd01-9722-4017-9deb-64a5d32478ff"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 ChainRulesCore = "1"
@@ -23,8 +21,8 @@ julia = "1"
 
 [extras]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Printf", "Test", "Random"]

--- a/examples/basic2D.jl
+++ b/examples/basic2D.jl
@@ -12,31 +12,46 @@ n = (30, 1, 15)
 d = (30.0, 30.0, 30.0)
 
 ## permeability
-K = 20 * md * ones(n)
+K0 = 200 * md * ones(n)
+K = deepcopy(K0)
+K[:,:,1:2:end] .*= 100
+
 ϕ = 0.25
 model = jutulModel(n, d, ϕ, K1to3(K))
 
 ## simulation time steppings
-tstep = 40 * ones(50)
+tstep = 50 * ones(10)
 tot_time = sum(tstep)
 
 ## injection & production
-inj_loc = (3, 1, 9) .* d
-prod_loc = (28, 1, 9) .* d
+inj_loc = (15, 1, 10) .* d
 irate = 5e-3
-q = jutulForce(irate, [inj_loc, prod_loc])
+q = jutulForce(irate, [inj_loc])
 
 ## set up modeling operator
 S = jutulModeling(model, tstep)
 
 ## simulation
 Trans = KtoTrans(CartesianMesh(model), K1to3(K))
-@time result = S(log.(Trans), q)
-@time result = S(log.(Trans), q)
+Trans0 = KtoTrans(CartesianMesh(model), K1to3(K0))
+@time states = S(log.(Trans), q)
+@time states0 = S(log.(Trans0), q)
 
 ## plotting
 fig=figure(figsize=(20,12));
 subplot(1,2,1);
-imshow(reshape(result.states[end].Saturations, n[1], n[end])', vmin=0, vmax=1); colorbar(); title("saturation")
+imshow(reshape(Saturations(states.states[end]), n[1], n[end])'); colorbar(); title("saturation")
 subplot(1,2,2);
-imshow(reshape(result.states[end].Pressure, n[1], n[end])', vmin=minimum(result.states[end].Pressure), vmax=maximum(result.states[end].Pressure)); colorbar(); title("pressure")
+imshow(reshape(Pressure(states.states[end]), n[1], n[end])'); colorbar(); title("pressure")
+
+## plotting
+fig=figure(figsize=(20,12));
+subplot(1,2,1);
+imshow(reshape(Saturations(states0.states[end]), n[1], n[end])'); colorbar(); title("saturation")
+subplot(1,2,2);
+imshow(reshape(Pressure(states0.states[end]), n[1], n[end])'); colorbar(); title("pressure")
+
+exist_co2 = sum(Saturations(states.states[end]) .* states.states[end].state[:Reservoir][:PhaseMassDensities][1,:] .* model.ϕ) * prod(model.d)
+inj_co2 = JutulDarcyAD.ρCO2 * q.irate * JutulDarcyAD.day * sum(tstep)
+
+norm(exist_co2-inj_co2)/norm(exist_co2+inj_co2)

--- a/examples/compass.jl
+++ b/examples/compass.jl
@@ -21,7 +21,7 @@ mkpath(plotsdir())
 ## grid size
 JLD2.@load datadir("BGCompass_tti_625m.jld2") m d;
 d = (6., 6.)
-m = m[:,181:end]
+m = m[200:450,181:end]
 h = 180 * d[end]
 v = Float64.(sqrt.(1f0./m));
 d = Float64.(d);
@@ -88,6 +88,7 @@ prj(x) = max.(min.(x,upper),lower)
 niterations = 100
 fhistory = zeros(niterations)
 fval = 0
+
 for j=1:niterations
 
     @time gs = gradient(Flux.params(logK0)) do

--- a/examples/compass.jl
+++ b/examples/compass.jl
@@ -24,7 +24,19 @@ d = (6., 6.)
 m = m[200:450,181:end]
 h = 180 * d[end]
 v = Float64.(sqrt.(1f0./m));
-d = Float64.(d);
+function downsample(v::Matrix{T}, factor::Int) where T
+    v_out_size = div.(size(v), factor)
+    v_out = zeros(T, v_out_size)
+    for i = 1:v_out_size[1]
+        for j = 1:v_out_size[2]
+            v_out[i,j] = mean(v[factor*i-factor+1:factor*i, factor*j-factor+1:factor*j])
+        end
+    end
+    return v_out
+end
+factor = 2
+v = 1.0./downsample(1.0./v, factor)
+d = Float64.(d) .* factor;
 function VtoK(v::Matrix{T}, d::Tuple{T, T}; α::T=T(20)) where T
 
     n = size(v)
@@ -49,7 +61,7 @@ d = (d[1], 2000.0, d[2])
 model = jutulModel(n, d, ϕ, K1to3(K; kvoverkh=0.36); h=h)
 
 ## simulation time steppings
-tstep = 320 * ones(25)
+tstep = 365.25 * ones(15)
 tot_time = sum(tstep)
 
 ## injection & production

--- a/examples/compass.jl
+++ b/examples/compass.jl
@@ -99,19 +99,18 @@ prj(x) = max.(min.(x,upper),lower)
 # Main loop
 niterations = 100
 fhistory = zeros(niterations)
-fval = 0
 
 for j=1:niterations
 
     @time gs = gradient(Flux.params(logK0)) do
-        global fval = f(logK0)
-        return fval
+        global loss = f(logK0)
+        return loss
     end
     g = gs[logK0]
     p = -g/norm(g, Inf)
     
-    println("Inversion iteration no: ",j,"; function value: ",fval)
-    fhistory[j] = fval
+    println("Inversion iteration no: ",j,"; function value: ",loss)
+    fhistory[j] = loss
 
     # linesearch
     function f_(α)
@@ -120,7 +119,7 @@ for j=1:niterations
         return misfit
     end
 
-    step, fval = ls(f_, 1e-1, fval, dot(g, p))
+    step, loss = ls(f_, 1e-1, loss, dot(g, p))
 
     # Update model and bound projection
     global logK0 = prj(logK0 .+ step .* p)

--- a/examples/compass.jl
+++ b/examples/compass.jl
@@ -62,7 +62,7 @@ S = jutulModeling(model, tstep)
 
 ## simulation
 mesh = CartesianMesh(model)
-T(x) = log.(KtoTrans(mesh, K1to3(exp.(x))))
+T(x) = log.(KtoTrans(mesh, K1to3(exp.(x); kvoverkh=0.36)))
 
 logK = log.(K)
 

--- a/examples/compass.jl
+++ b/examples/compass.jl
@@ -20,6 +20,9 @@ mkpath(plotsdir())
 
 ## grid size
 JLD2.@load datadir("BGCompass_tti_625m.jld2") m d;
+d = (6., 6.)
+m = m[:,181:end]
+h = 180 * d[end]
 v = Float64.(sqrt.(1f0./m));
 d = Float64.(d);
 function VtoK(v::Matrix{T}, d::Tuple{T, T}; α::T=T(20)) where T
@@ -40,17 +43,17 @@ end
 Kh = VtoK(v, d);
 K = Float64.(Kh * md);
 n = (size(K,1), 1, size(K,2))
-d = (d[1], 1000.0, d[2])
+d = (d[1], 2000.0, d[2])
 
 ϕ = 0.25
-model = jutulModel(n, d, ϕ, K1to3(K))
+model = jutulModel(n, d, ϕ, K1to3(K; kvoverkh=0.36); h=h)
 
 ## simulation time steppings
-tstep = 160 * ones(50)
+tstep = 320 * ones(25)
 tot_time = sum(tstep)
 
 ## injection & production
-inj_loc = (Int(round(n[1]/2)), 1, n[end]-60) .* d
+inj_loc = (Int(round(n[1]/2)), 1, n[end]-20) .* d
 irate = 0.3
 q = jutulForce(irate, [inj_loc])
 
@@ -68,9 +71,9 @@ logK = log.(K)
 ## plotting
 fig=figure(figsize=(20,12));
 subplot(1,2,1);
-imshow(reshape(Saturations(state.states[25]), n[1], n[end])'); colorbar(); title("saturation")
+imshow(reshape(Saturations(state.states[end]), n[1], n[end])'); colorbar(); title("saturation")
 subplot(1,2,2);
-imshow(reshape(Pressure(state.states[25]), n[1], n[end])'); colorbar(); title("pressure")
+imshow(reshape(Pressure(state.states[end]), n[1], n[end])'); colorbar(); title("pressure")
 
 #### inversion
 logK0 = deepcopy(logK)

--- a/examples/compass.jl
+++ b/examples/compass.jl
@@ -80,16 +80,13 @@ logK = log.(K)
 
 @time state = S(T(logK), q)
 
-## plotting
-fig=figure(figsize=(20,12));
-subplot(1,2,1);
-imshow(reshape(Saturations(state.states[end]), n[1], n[end])'); colorbar(); title("saturation")
-subplot(1,2,2);
-imshow(reshape(Pressure(state.states[end]), n[1], n[end])'); colorbar(); title("pressure")
-
 #### inversion
 logK0 = deepcopy(logK)
 logK0[v.>3.5] .= mean(logK[v.>3.5])
+logK0[logK0.==minimum(logK0)] .= mean(logK[v.>3.5])
+logK_init = deepcopy(logK0)
+
+state_init = S(T(logK_init), q)
 
 f(logK) = .5 * norm(S(T(logK),q)[1:length(tstep)*prod(n)]-state[1:length(tstep)*prod(n)])^2
 ls = BackTracking(order=3, iterations=10)
@@ -126,13 +123,45 @@ for j=1:niterations
     ### plotting
     fig=figure(figsize=(20,12));
     subplot(1,3,1);
-    imshow(exp.(logK)', vmin=minimum(exp.(logK)), vmax=maximum(exp.(logK))); colorbar(); title("true permeability")
+    imshow(exp.(logK)'./md, vmin=minimum(exp.(logK))./md, vmax=maximum(exp.(logK)./md)); colorbar(); title("true permeability")
     subplot(1,3,2);
-    imshow(exp.(logK0)', vmin=minimum(exp.(logK)), vmax=maximum(exp.(logK))); colorbar(); title("inverted permeability")
+    imshow(exp.(logK0)'./md, vmin=minimum(exp.(logK))./md, vmax=maximum(exp.(logK)./md)); colorbar(); title("inverted permeability")
     subplot(1,3,3);
-    imshow(exp.(logK)'.-exp.(logK0)', vmin=minimum(exp.(logK)), vmax=maximum(exp.(logK))); colorbar(); title("diff")
+    imshow(exp.(logK)'./md.-exp.(logK0)'./md, vmin=minimum(exp.(logK)), vmax=maximum(exp.(logK)./md)); colorbar(); title("diff")
+    suptitle("Flow Inversion at iter $j")
     tight_layout()
     safesave(joinpath(plotsdir(sim_name, exp_name), savename(fig_name; digits=6)*"_diff.png"), fig);
+    close(fig)
+
+    state_predict = S(T(logK0), q)
+
+    ## data fitting
+    fig = figure(figsize=(20,12));
+    for i = 1:5
+        subplot(4,5,i);
+        imshow(reshape(Saturations(state_init.states[3*i]), n[1], n[end])', vmin=0, vmax=0.9); colorbar();
+        title("initial prediction at snapshot $(3*i)")
+        subplot(4,5,i+5);
+        imshow(reshape(Saturations(state.states[3*i]), n[1], n[end])', vmin=0, vmax=0.9); colorbar();
+        title("true at snapshot $(3*i)")
+        subplot(4,5,i+10);
+        imshow(reshape(Saturations(state_predict.states[3*i]), n[1], n[end])', vmin=0, vmax=0.9); colorbar();
+        title("predict at snapshot $(3*i)")
+        subplot(4,5,i+15);
+        imshow(5*abs.(reshape(Saturations(state.states[3*i]), n[1], n[end])'-reshape(Saturations(state_predict.states[3*i]), n[1], n[end])'), vmin=0, vmax=0.9); colorbar();
+        title("5X diff at snapshot $(3*i)")
+    end
+    suptitle("Flow Inversion at iter $j")
+    tight_layout()
+    safesave(joinpath(plotsdir(sim_name, exp_name), savename(fig_name; digits=6)*"_co2.png"), fig);
+    close(fig)
+
+    ## loss
+    fig = figure(figsize=(20,12));
+    plot(fhistory[1:j]);title("loss=$(fhistory[j])");
+    suptitle("Flow Inversion at iter $j")
+    tight_layout()
+    safesave(joinpath(plotsdir(sim_name, exp_name), savename(fig_name; digits=6)*"_loss.png"), fig);
     close(fig)
 
 end

--- a/examples/compass.jl
+++ b/examples/compass.jl
@@ -102,15 +102,12 @@ fhistory = zeros(niterations)
 
 for j=1:niterations
 
-    @time gs = gradient(Flux.params(logK0)) do
-        global loss = f(logK0)
-        return loss
-    end
+    @time fval, gs = Flux.withgradient(() -> f(logK0), Flux.params(logK0))
     g = gs[logK0]
     p = -g/norm(g, Inf)
     
-    println("Inversion iteration no: ",j,"; function value: ",loss)
-    fhistory[j] = loss
+    println("Inversion iteration no: ",j,"; function value: ",fval)
+    fhistory[j] = fval
 
     # linesearch
     function f_(α)
@@ -119,7 +116,7 @@ for j=1:niterations
         return misfit
     end
 
-    step, loss = ls(f_, 1e-1, loss, dot(g, p))
+    step, fval = ls(f_, 1e-1, fval, dot(g, p))
 
     # Update model and bound projection
     global logK0 = prj(logK0 .+ step .* p)

--- a/examples/compass.jl
+++ b/examples/compass.jl
@@ -105,6 +105,7 @@ for j=1:niterations
 
     @time gs = gradient(Flux.params(logK0)) do
         global fval = f(logK0)
+        return fval
     end
     g = gs[logK0]
     p = -g/norm(g, Inf)

--- a/examples/compass.jl
+++ b/examples/compass.jl
@@ -1,0 +1,127 @@
+## A 2D compass example
+
+using DrWatson
+@quickactivate "JutulDarcyAD-example"
+
+using JutulDarcyAD
+using LinearAlgebra
+using PyPlot
+using Flux
+using LineSearches
+using JLD2
+using JUDI
+using Statistics
+
+sim_name = "2D-K-inv"
+exp_name = "compass"
+
+mkpath(datadir())
+mkpath(plotsdir())
+
+## grid size
+JLD2.@load datadir("BGCompass_tti_625m.jld2") m d;
+v = Float64.(sqrt.(1f0./m));
+d = Float64.(d);
+function VtoK(v::Matrix{T}, d::Tuple{T, T}; α::T=T(20)) where T
+
+    n = size(v)
+    idx_wb = find_water_bottom(v.-minimum(v))
+    idx_ucfmt = find_water_bottom((v.-T(3.5)).*(v.>T(3.5)))
+    Kh = zeros(T, n)
+    capgrid = Int(round(T(50)/d[2]))
+    for i = 1:n[1]
+        Kh[i,1:idx_wb[i]-1] .= T(1e-10)  # water layer
+        Kh[i,idx_wb[i]:idx_ucfmt[i]-capgrid-1] .= α*exp.(v[i,idx_wb[i]:idx_ucfmt[i]-capgrid-1])
+        Kh[i,idx_ucfmt[i]-capgrid:idx_ucfmt[i]-1] .= T(1e-3)
+        Kh[i,idx_ucfmt[i]:end] .= α*exp.(v[i,idx_ucfmt[i]:end]) .- α*exp(T(3.5))
+    end
+    return Kh
+end
+Kh = VtoK(v, d);
+K = Float64.(Kh * md);
+n = (size(K,1), 1, size(K,2))
+d = (d[1], 1000.0, d[2])
+
+ϕ = 0.25
+model = jutulModel(n, d, ϕ, K1to3(K))
+
+## simulation time steppings
+tstep = 160 * ones(50)
+tot_time = sum(tstep)
+
+## injection & production
+inj_loc = (Int(round(n[1]/2)), 1, n[end]-60) .* d
+irate = 0.3
+q = jutulForce(irate, [inj_loc])
+
+## set up modeling operator
+S = jutulModeling(model, tstep)
+
+## simulation
+mesh = CartesianMesh(model)
+T(x) = log.(KtoTrans(mesh, K1to3(exp.(x))))
+
+logK = log.(K)
+
+@time state = S(T(logK), q)
+
+## plotting
+fig=figure(figsize=(20,12));
+subplot(1,2,1);
+imshow(reshape(Saturations(state.states[25]), n[1], n[end])'); colorbar(); title("saturation")
+subplot(1,2,2);
+imshow(reshape(Pressure(state.states[25]), n[1], n[end])'); colorbar(); title("pressure")
+
+#### inversion
+logK0 = deepcopy(logK)
+logK0[v.>3.5] .= mean(logK[v.>3.5])
+
+f(logK) = .5 * norm(S(T(logK),q)[1:length(tstep)*prod(n)]-state[1:length(tstep)*prod(n)])^2
+ls = BackTracking(order=3, iterations=10)
+
+lower, upper = 1.1*minimum(logK), 0.9*maximum(logK)
+prj(x) = max.(min.(x,upper),lower)
+# Main loop
+niterations = 100
+fhistory = zeros(niterations)
+fval = 0
+for j=1:niterations
+
+    @time gs = gradient(Flux.params(logK0)) do
+        global fval = f(logK0)
+    end
+    g = gs[logK0]
+    p = -g/norm(g, Inf)
+    
+    println("Inversion iteration no: ",j,"; function value: ",fval)
+    fhistory[j] = fval
+
+    # linesearch
+    function f_(α)
+        misfit = f(prj(logK0 .+ α * p))
+        @show α, misfit
+        return misfit
+    end
+
+    step, fval = ls(f_, 1e-1, fval, dot(g, p))
+
+    # Update model and bound projection
+    global logK0 = prj(logK0 .+ step .* p)
+
+    fig_name = @strdict j n d ϕ tstep irate niterations lower upper inj_loc
+
+    ### plotting
+    fig=figure(figsize=(20,12));
+    subplot(1,3,1);
+    imshow(exp.(logK)', vmin=minimum(exp.(logK)), vmax=maximum(exp.(logK))); colorbar(); title("true permeability")
+    subplot(1,3,2);
+    imshow(exp.(logK0)', vmin=minimum(exp.(logK)), vmax=maximum(exp.(logK))); colorbar(); title("inverted permeability")
+    subplot(1,3,3);
+    imshow(exp.(logK)'.-exp.(logK0)', vmin=minimum(exp.(logK)), vmax=maximum(exp.(logK))); colorbar(); title("diff")
+    tight_layout()
+    safesave(joinpath(plotsdir(sim_name, exp_name), savename(fig_name; digits=6)*"_diff.png"), fig);
+    close(fig)
+
+end
+
+JLD2.@save "compass-inv.jld2" logK logK0 state

--- a/examples/inv_logK.jl
+++ b/examples/inv_logK.jl
@@ -63,12 +63,15 @@ fhistory = zeros(niterations)
 
 for j=1:niterations
 
-    fval = f(logK0)
-    g = gradient(()->f(logK0), Flux.params(logK0))[logK0]
-    p = -g
+    @time gs = gradient(Flux.params(logK0)) do
+        global loss = f(logK0)
+        return loss
+    end
+    g = gs[logK0]
+    p = -g/norm(g, Inf)
     
-    println("Inversion iteration no: ",j,"; function value: ",fval)
-    fhistory[j] = fval
+    println("Inversion iteration no: ",j,"; function value: ", loss)
+    fhistory[j] = loss
 
     # linesearch
     function f_(α)
@@ -77,7 +80,7 @@ for j=1:niterations
         return misfit
     end
 
-    step, fval = ls(f_, 1e-1, fval, dot(g, p))
+    step, loss = ls(f_, 1e-1, loss, dot(g, p))
 
     # Update model and bound projection
     global logK0 = prj(logK0 .+ step .* p)

--- a/examples/inv_logK.jl
+++ b/examples/inv_logK.jl
@@ -33,7 +33,7 @@ tstep = 40 * ones(50)
 tot_time = sum(tstep)
 
 ## injection & production
-inj_loc = (3, 1, 9) .* d
+inj_loc = (15, 1, 9) .* d
 irate = 5e-3
 q = jutulForce(irate, [inj_loc])
 

--- a/examples/inv_logK.jl
+++ b/examples/inv_logK.jl
@@ -63,15 +63,12 @@ fhistory = zeros(niterations)
 
 for j=1:niterations
 
-    @time gs = gradient(Flux.params(logK0)) do
-        global loss = f(logK0)
-        return loss
-    end
+    @time fval, gs = Flux.withgradient(() -> f(logK0), Flux.params(logK0))
     g = gs[logK0]
     p = -g/norm(g, Inf)
     
-    println("Inversion iteration no: ",j,"; function value: ", loss)
-    fhistory[j] = loss
+    println("Inversion iteration no: ",j,"; function value: ", fval)
+    fhistory[j] = fval
 
     # linesearch
     function f_(α)
@@ -80,7 +77,7 @@ for j=1:niterations
         return misfit
     end
 
-    step, loss = ls(f_, 1e-1, loss, dot(g, p))
+    step, fval = ls(f_, 1e-1, fval, dot(g, p))
 
     # Update model and bound projection
     global logK0 = prj(logK0 .+ step .* p)

--- a/examples/inv_logK.jl
+++ b/examples/inv_logK.jl
@@ -88,7 +88,7 @@ state0 = S(T(logK0), q)
 K0 = exp.(logK0)
 K_init = exp.(logK_init)
 
-fig_name = @strdict n d ϕ tstep irate niterations lower upper inj_loc prod_loc
+fig_name = @strdict n d ϕ tstep irate niterations lower upper inj_loc
 
 fig=figure(figsize=(20,12));
 subplot(1,3,1);
@@ -103,22 +103,22 @@ close(fig)
 
 fig=figure(figsize=(20,12));
 subplot(1,3,1);
-imshow(reshape(state_init.states[end].Saturations, n[1], n[end])', vmin=0, vmax=1); colorbar(); title("initial saturation")
+imshow(reshape(Saturations(state_init.states[end]), n[1], n[end])', vmin=0, vmax=1); colorbar(); title("initial saturation")
 subplot(1,3,2);
-imshow(reshape(state0.states[end].Saturations, n[1], n[end])', vmin=0, vmax=1); colorbar(); title("inverted saturation")
+imshow(reshape(Saturations(state0.states[end]), n[1], n[end])', vmin=0, vmax=1); colorbar(); title("inverted saturation")
 subplot(1,3,3);
-imshow(reshape(state.states[end].Saturations, n[1], n[end])', vmin=0, vmax=1); colorbar(); title("true saturation")
+imshow(reshape(Saturations(state.states[end]), n[1], n[end])', vmin=0, vmax=1); colorbar(); title("true saturation")
 tight_layout()
 safesave(joinpath(plotsdir(sim_name, exp_name), savename(fig_name; digits=6)*"_saturation.png"), fig);
 close(fig)
 
 fig=figure(figsize=(20,12));
 subplot(1,3,1);
-imshow(reshape(state_init.states[end].Pressure, n[1], n[end])', vmin=minimum(state.states[end].Pressure), vmax=maximum(state.states[end].Pressure)); colorbar(); title("initial pressure")
+imshow(reshape(Pressure(state_init.states[end]), n[1], n[end])', vmin=minimum(state.states[end].Pressure), vmax=maximum(state.states[end].Pressure)); colorbar(); title("initial pressure")
 subplot(1,3,2);
-imshow(reshape(state0.states[end].Pressure, n[1], n[end])', vmin=minimum(state.states[end].Pressure), vmax=maximum(state.states[end].Pressure)); colorbar(); title("inverted pressure")
+imshow(reshape(Pressure(state0.states[end]), n[1], n[end])', vmin=minimum(state.states[end].Pressure), vmax=maximum(state.states[end].Pressure)); colorbar(); title("inverted pressure")
 subplot(1,3,3);
-imshow(reshape(state.states[end].Pressure, n[1], n[end])', vmin=minimum(state.states[end].Pressure), vmax=maximum(state.states[end].Pressure)); colorbar(); title("true pressure")
+imshow(reshape(Pressure(state.states[end]), n[1], n[end])', vmin=minimum(state.states[end].Pressure), vmax=maximum(state.states[end].Pressure)); colorbar(); title("true pressure")
 tight_layout()
 safesave(joinpath(plotsdir(sim_name, exp_name), savename(fig_name; digits=6)*"_pressure.png"), fig);
 close(fig)

--- a/examples/inv_logK.jl
+++ b/examples/inv_logK.jl
@@ -34,9 +34,8 @@ tot_time = sum(tstep)
 
 ## injection & production
 inj_loc = (3, 1, 9) .* d
-prod_loc = (28, 1, 9) .* d
 irate = 5e-3
-q = jutulForce(irate, [inj_loc, prod_loc])
+q = jutulForce(irate, [inj_loc])
 
 ## set up modeling operator
 S = jutulModeling(model, tstep)

--- a/examples/simple_2D.jl
+++ b/examples/simple_2D.jl
@@ -1,0 +1,42 @@
+## A simple 2D example for fluid-flow simulation
+
+using DrWatson
+@quickactivate "JutulDarcyAD-example"
+
+using JutulDarcyAD
+using LinearAlgebra
+using PyPlot
+
+## grid size
+n = (30, 1, 15)
+d = (30.0, 30.0, 30.0)
+
+## permeability
+K = 20 * md * ones(n)
+ϕ = 0.25 * ones(n)
+model = jutulModel(n, d, vec(ϕ), K1to3(K))
+
+## simulation time steppings
+tstep = 40 * ones(50)
+tot_time = sum(tstep)
+
+## injection & production
+inj_loc = (3, 1, 9) .* d
+prod_loc = (28, 1, 9) .* d
+irate = 5e-3
+q = jutulSource(irate, [inj_loc, prod_loc])
+
+## set up modeling operator
+S = jutulModeling(model, tstep)
+
+## simulation
+Trans = KtoTrans(CartesianMesh(model), K1to3(K))
+@time result = S(log.(Trans), q; info_level=1)
+@time result = S(log.(Trans), q)
+
+## plotting
+fig=figure(figsize=(20,12));
+subplot(1,2,1);
+imshow(reshape(Saturations(result.states[end]), n[1], n[end])', vmin=0, vmax=1); colorbar(); title("saturation")
+subplot(1,2,2);
+imshow(reshape(Pressure(result.states[end]), n[1], n[end])', vmin=minimum(Pressure(result.states[end])), vmax=maximum(Pressure(result.states[end]))); colorbar(); title("pressure")

--- a/src/FlowAD/FlowAD.jl
+++ b/src/FlowAD/FlowAD.jl
@@ -1,6 +1,7 @@
 ### types
 include("Types/jutulModel.jl")
 include("Types/jutulForce.jl")
+include("Types/jutulSource.jl")
 include("Types/jutulState.jl")
 include("Types/type_utils.jl")
 

--- a/src/FlowAD/FlowAD.jl
+++ b/src/FlowAD/FlowAD.jl
@@ -1,9 +1,8 @@
-const kr = BrooksCoreyRelPerm(sys, [2.0, 2.0])
-
 ### types
 include("Types/jutulModel.jl")
 include("Types/jutulForce.jl")
 include("Types/jutulState.jl")
+include("Types/type_utils.jl")
 
 ### operators
 include("Operators/jutulModeling.jl")

--- a/src/FlowAD/Operators/jutulModeling.jl
+++ b/src/FlowAD/Operators/jutulModeling.jl
@@ -13,11 +13,26 @@ function (S::jutulModeling{D, T})(LogTransmissibilities::AbstractVector{T}, f::j
     ρCO2::T=T(ρCO2), ρH2O::T=T(ρH2O), info_level::Int64=-1) where {D, T, N}
 
     Transmissibilities = exp.(LogTransmissibilities)
-    forces = force(S.model, f; ρCO2=ρCO2)
+
+    sys = ImmiscibleSystem((VaporPhase(), AqueousPhase()), reference_densities = [ρH2O, ρCO2])
+
+    ### set up model, parameters
+    domain = discretized_domain_tpfv_flow(tpfv_geometry(CartesianMesh(S.model)), porosity = S.model.ϕ, permeability = S.model.K)
+    model, parameters = setup_reservoir_model(domain, sys, wells = Is)
+    select_output_variables!(model.models.Reservoir, :all)
+    ρ = ConstantCompressibilityDensities(p_ref = 150*bar, density_ref = rhoS, compressibility = c)
+    replace_variables!(model, PhaseMassDensities = ρ)
+    replace_variables!(model, PhaseViscosities = [visCO2, visH2O])
+    model.models.Reservoir.domain.grid.trans .= Transmissibilities
+
+    ### set up well controls
     tstep = day * S.tstep
-    model = model_(S.model; ρCO2=ρCO2, ρH2O=ρH2O)
-    model.domain.grid.trans .= Transmissibilities
-    parameters = setup_parameters(model, PhaseViscosities = [visCO2, visH2O]); # 0.1 and 1 cP
-    states, _ = simulate(dict(state0), model, tstep, parameters = parameters, forces = forces, info_level = info_level, max_timestep_cuts = 1000)
+    Is, controls = force(S.model, f,tstep; ρCO2=ρCO2)    
+    forces = setup_reservoir_forces(model, control = controls)
+    
+    ### simulation
+    sim, config = setup_reservoir_simulator(model, state0, parameters);
+    states, _ = simulate!(sim, tstep, forces = forces, config = config, info_level = info_level, max_timestep_cuts = 1000);
+
     return jutulStates(states)
 end

--- a/src/FlowAD/Operators/jutulModeling.jl
+++ b/src/FlowAD/Operators/jutulModeling.jl
@@ -9,30 +9,28 @@ display(M::jutulModeling{D, T}) where {D, T} =
     println("$(D)D jutulModeling structure with $(sum(M.tstep)) days in $(length(M.tstep)) time steps")
 
 function (S::jutulModeling{D, T})(LogTransmissibilities::AbstractVector{T}, f::jutulForce{D, N};
-    state0::jutulState{T}=jutulState(S.model), visCO2::T=T(visCO2), visH2O::T=T(visH2O),
+    state0=nothing, visCO2::T=T(visCO2), visH2O::T=T(visH2O),
     ρCO2::T=T(ρCO2), ρH2O::T=T(ρH2O), info_level::Int64=-1) where {D, T, N}
 
     Transmissibilities = exp.(LogTransmissibilities)
 
-    sys = ImmiscibleSystem((VaporPhase(), AqueousPhase()), reference_densities = [ρH2O, ρCO2])
-
-    ### set up model, parameters
-    domain = discretized_domain_tpfv_flow(tpfv_geometry(CartesianMesh(S.model)), porosity = S.model.ϕ, permeability = S.model.K)
-    model, parameters = setup_reservoir_model(domain, sys, wells = Is)
-    select_output_variables!(model.models.Reservoir, :all)
-    ρ = ConstantCompressibilityDensities(p_ref = 150*bar, density_ref = rhoS, compressibility = c)
-    replace_variables!(model, PhaseMassDensities = ρ)
-    replace_variables!(model, PhaseViscosities = [visCO2, visH2O])
-    model.models.Reservoir.domain.grid.trans .= Transmissibilities
-
-    ### set up well controls
+    ### set up simulation time
     tstep = day * S.tstep
-    Is, controls = force(S.model, f,tstep; ρCO2=ρCO2)    
-    forces = setup_reservoir_forces(model, control = controls)
-    
+
+    ### set up simulation configurations
+    model, parameters, state0_, forces = setup_well_model(S.model, f, tstep; visCO2=visCO2, visH2O=visH2O, ρCO2=ρCO2, ρH2O=ρH2O)
+    model.models.Reservoir.domain.grid.trans .= Transmissibilities
+    parameters[:Reservoir][:Transmissibilities] = Transmissibilities
+
+    if isnothing(state0)
+        state0 = state0_
+    else
+        state0 = dict(state0)
+    end
+
     ### simulation
     sim, config = setup_reservoir_simulator(model, state0, parameters);
-    states, _ = simulate!(sim, tstep, forces = forces, config = config, info_level = info_level, max_timestep_cuts = 1000);
-
-    return jutulStates(states)
+    states, report = simulate!(sim, tstep, forces = forces, config = config, max_timestep_cuts = 1000, info_level=info_level);
+    output = jutulStates(states)
+    return output
 end

--- a/src/FlowAD/Operators/rrule.jl
+++ b/src/FlowAD/Operators/rrule.jl
@@ -20,7 +20,7 @@ function rrule(S::jutulModeling{D, T}, LogTransmissibilities::AbstractVector{T},
 
     ### simulation
     sim, config = setup_reservoir_simulator(model, state0, parameters);
-    states, report = simulate!(sim, tstep, forces = forces, config = config, max_timestep_cuts = 1000, info_level=info_level);
+    states, reports = simulate!(sim, tstep, forces = forces, config = config, max_timestep_cuts = 1000, info_level=info_level);
     output = jutulStates(states)
     
     ### optimization framework
@@ -33,9 +33,8 @@ function rrule(S::jutulModeling{D, T}, LogTransmissibilities::AbstractVector{T},
         states_ref = dict(states_ref_)
         mass_mismatch = (m, state, dt, step_no, forces) -> loss_per_step(m, state, dt, step_no, forces, states_ref)
         F_o, dF_o, F_and_dF, x0, lims, data = setup_parameter_optimization(
-            model, state0, parameters, tstep, forces, mass_mismatch, cfg, param_obj = true, print = info_level, config = config, use_sparsity = false);
-        g = similar(x0);
-        misfit = F_and_dF(F_o, g, x0);
+            states, reports, model, state0, parameters, tstep, forces, mass_mismatch, cfg, param_obj = true, print = info_level, config = config, use_sparsity = false);
+        g = dF_o(similar(x0), x0);
         return NoTangent(), g[1:length(LogTransmissibilities)], NoTangent()
     end
     return output, pullback
@@ -62,4 +61,92 @@ function inner_mismatch(val, ref, val2, ref2)
         mismatch_p += (val2[i] - ref2[i])^2
     end
     return eltype(val)(0.5) * mismatch_s + eltype(val2)(0.5) * mismatch_p
+end
+
+function setup_parameter_optimization(precomputed_states, reports, model, state0, param, dt, forces, G, arg...; kwarg...)
+    case = JutulCase(model, dt, forces, state0 = state0, parameters = param)
+    return setup_parameter_optimization(precomputed_states, reports, case, G, arg...; kwarg...)
+end
+
+function setup_parameter_optimization(precomputed_states, reports, case::JutulCase, G, opt_cfg = optimization_config(case.model, case.parameters);
+                                                            grad_type = :adjoint,
+                                                            config = nothing,
+                                                            print = 1,
+                                                            copy_case = true,
+                                                            param_obj = false,
+                                                            use_sparsity = true,
+                                                            kwarg...)
+    if copy_case
+        case = Jutul.duplicate(case)
+    end
+    # Pick active set of targets from the optimization config and construct a mapper
+    (; model, state0, parameters) = case
+    if print isa Bool
+        if print
+            print = 1
+        else
+            print = Inf
+        end
+    end
+    verbose = print > 0 && isfinite(print)
+    targets = Jutul.optimization_targets(opt_cfg, model)
+    if grad_type == :numeric
+        @assert length(targets) == 1
+        @assert model isa SimulationModel
+    else
+        @assert grad_type == :adjoint
+    end
+    mapper, = Jutul.variable_mapper(model, :parameters, targets = targets, config = opt_cfg)
+    lims = Jutul.optimization_limits(opt_cfg, mapper, parameters, model)
+    if verbose
+        Jutul.print_parameter_optimization_config(targets, opt_cfg, model)
+    end
+    x0 = Jutul.vectorize_variables(model, parameters, mapper, config = opt_cfg)
+    for k in eachindex(x0)
+        low = lims[1][k]
+        high = lims[2][k]
+        @assert low <= x0[k] "Computed lower limit $low for parameter #$k was larger than provided x0[k]=$(x0[k])"
+        @assert high >= x0[k] "Computer upper limit $hi for parameter #$k was smaller than provided x0[k]=$(x0[k])"
+    end
+    data = Dict()
+    data[:n_objective] = 1
+    data[:n_gradient] = 1
+    data[:obj_hist] = zeros(0)
+
+    sim = Jutul.Simulator(case)
+    if isnothing(config)
+        config = Jutul.simulator_config(sim; info_level = -1, kwarg...)
+    elseif !verbose
+        config[:info_level] = -1
+        config[:end_report] = false
+    end
+    data[:sim] = sim
+    data[:sim_config] = config
+
+    if grad_type == :adjoint
+        adj_storage = Jutul.setup_adjoint_storage(model, state0 = state0,
+                                                   parameters = parameters,
+                                                   targets = targets,
+                                                   use_sparsity = use_sparsity,
+                                                   param_obj = param_obj)
+        data[:adjoint_storage] = adj_storage
+        grad_adj = zeros(adj_storage.n)
+    else
+        grad_adj = similar(x0)
+    end
+    data[:case] = case
+    data[:grad_adj] = grad_adj
+    data[:mapper] = mapper
+    data[:G] = G
+    data[:targets] = targets
+    data[:mapper] = mapper
+    data[:config] = opt_cfg
+    data[:last_obj] = Inf
+    data[:x_hash] = hash(x0)
+    data[:states] = precomputed_states
+    data[:reports] = reports
+    F = x -> Jutul.objective_opt!(x, data, print)
+    dF = (dFdx, x) -> Jutul.gradient_opt!(dFdx, x, data)
+    F_and_dF = (F, dFdx, x) -> Jutul.objective_and_gradient_opt!(F, dFdx, x, data, print)
+    return (F! = F, dF! = dF, F_and_dF! = F_and_dF, x0 = x0, limits = lims, data = data)
 end

--- a/src/FlowAD/Operators/rrule.jl
+++ b/src/FlowAD/Operators/rrule.jl
@@ -49,5 +49,17 @@ function loss_per_step(m, state, dt, step_no, forces, states_ref)
     val2 = state[:Reservoir][fld2]
     ref = state_ref[:Reservoir][fld]
     ref2 = state_ref[:Reservoir][fld2]
-    return 0.5 * sum((val[1,:] - ref[1,:]).^2) + 0.5 * sum((val2-ref2).^2)
+    return inner_mismatch(val, ref, val2, ref2)
+end
+
+function inner_mismatch(val, ref, val2, ref2)
+    mismatch_s = zero(eltype(val))
+    for i in axes(val, 2)
+        mismatch_s += (val[1,i] - ref[1,i])^2
+    end
+    mismatch_p = zero(eltype(val2))
+    for i in eachindex(val2)
+        mismatch_p += (val2[i] - ref2[i])^2
+    end
+    return eltype(val)(0.5) * mismatch_s + eltype(val2)(0.5) * mismatch_p
 end

--- a/src/FlowAD/Operators/rrule.jl
+++ b/src/FlowAD/Operators/rrule.jl
@@ -33,7 +33,7 @@ function rrule(S::jutulModeling{D, T}, LogTransmissibilities::AbstractVector{T},
         states_ref = dict(states_ref_)
         mass_mismatch = (m, state, dt, step_no, forces) -> loss_per_step(m, state, dt, step_no, forces, states_ref)
         F_o, dF_o, F_and_dF, x0, lims, data = setup_parameter_optimization(
-            model, state0, parameters, tstep, forces, mass_mismatch, cfg, param_obj = true, print = info_level, config = config);
+            model, state0, parameters, tstep, forces, mass_mismatch, cfg, param_obj = true, print = info_level, config = config, use_sparsity = false);
         g = similar(x0);
         misfit = F_and_dF(F_o, g, x0);
         return NoTangent(), g[1:length(LogTransmissibilities)], NoTangent()

--- a/src/FlowAD/Operators/rrule.jl
+++ b/src/FlowAD/Operators/rrule.jl
@@ -40,6 +40,55 @@ function rrule(S::jutulModeling{D, T}, LogTransmissibilities::AbstractVector{T},
     return output, pullback
 end
 
+function rrule(S::jutulModeling{D, T}, LogTransmissibilities::AbstractVector{T}, f::jutulSource{D, N};
+    state0::jutulSimpleState{T}=jutulSimpleState(S.model), visCO2::T=T(visCO2), visH2O::T=T(visH2O),
+    ρCO2::T=T(ρCO2), ρH2O::T=T(ρH2O), info_level::Int64=-1) where {D, T, N}
+    
+    Transmissibilities = exp.(LogTransmissibilities)
+
+    forces = source(S.model, f; ρCO2=ρCO2)
+
+    ### set up simulation time
+    tstep = day * S.tstep
+    model = simple_model(S.model; ρCO2=ρCO2, ρH2O=ρH2O)
+    model.domain.grid.trans .= Transmissibilities
+    parameters = setup_parameters(model, PhaseViscosities = [visCO2, visH2O]);
+    states, reports = simulate(dict(state0), model, tstep, parameters = parameters, forces = forces, info_level = info_level, max_timestep_cuts = 1000)
+    output = jutulSimpleStates(states)
+    cfg = optimization_config(model, parameters, use_scaling = true, rel_min = 0.1, rel_max = 10)
+    for (ki, vi) in cfg
+        if ki in [:TwoPointGravityDifference, :PhaseViscosities]
+            vi[:active] = false
+        end
+        if ki == :Transmissibilities
+            vi[:scaler] = :log
+        end
+    end
+    cfg[:Transmissibilities][:use_scaling] = false
+
+    function pullback(dy)
+        states_dy = output(dy)
+        states_ref = dict(output-states_dy)
+        function mass_mismatch(m, state, dt, step_no, forces)
+            state_ref = states_ref[step_no]
+            fld = :Saturations
+            fld2 = :Pressure
+            val = state[fld]
+            val2 = state[fld2]
+            ref = state_ref[fld]
+            ref2 = state_ref[fld2]
+            return 0.5 * sum((val[1,:] - ref[1,:]).^2) + 0.5 * sum((val2-ref2).^2)
+        end
+        mass_mismatch = (m, state, dt, step_no, forces) -> loss_per_step_simple(m, state, dt, step_no, forces, states_ref)
+        Jutul.evaluate_objective(mass_mismatch, model, states_ref, tstep, forces)
+        F_o, dF_o, F_and_dF, x0, lims, data = setup_parameter_optimization(states, reports, model,
+        dict(state0), parameters, tstep, forces, mass_mismatch, cfg, print = -1, param_obj = true);
+        g = dF_o(similar(x0), x0);
+        return NoTangent(), g[1:length(LogTransmissibilities)], NoTangent()
+    end
+    return output, pullback
+end
+
 function loss_per_step(m, state, dt, step_no, forces, states_ref)
     state_ref = states_ref[step_no]
     fld = :Saturations
@@ -48,6 +97,17 @@ function loss_per_step(m, state, dt, step_no, forces, states_ref)
     val2 = state[:Reservoir][fld2]
     ref = state_ref[:Reservoir][fld]
     ref2 = state_ref[:Reservoir][fld2]
+    return inner_mismatch(val, ref, val2, ref2)
+end
+
+function loss_per_step_simple(m, state, dt, step_no, forces, states_ref)
+    state_ref = states_ref[step_no]
+    fld = :Saturations
+    fld2 = :Pressure
+    val = state[fld]
+    val2 = state[fld2]
+    ref = state_ref[fld]
+    ref2 = state_ref[fld2]
     return inner_mismatch(val, ref, val2, ref2)
 end
 
@@ -89,19 +149,19 @@ function setup_parameter_optimization(precomputed_states, reports, case::JutulCa
         end
     end
     verbose = print > 0 && isfinite(print)
-    targets = Jutul.optimization_targets(opt_cfg, model)
+    targets = optimization_targets(opt_cfg, model)
     if grad_type == :numeric
         @assert length(targets) == 1
         @assert model isa SimulationModel
     else
         @assert grad_type == :adjoint
     end
-    mapper, = Jutul.variable_mapper(model, :parameters, targets = targets, config = opt_cfg)
-    lims = Jutul.optimization_limits(opt_cfg, mapper, parameters, model)
+    mapper, = variable_mapper(model, :parameters, targets = targets, config = opt_cfg)
+    lims = optimization_limits(opt_cfg, mapper, parameters, model)
     if verbose
-        Jutul.print_parameter_optimization_config(targets, opt_cfg, model)
+        print_parameter_optimization_config(targets, opt_cfg, model)
     end
-    x0 = Jutul.vectorize_variables(model, parameters, mapper, config = opt_cfg)
+    x0 = vectorize_variables(model, parameters, mapper, config = opt_cfg)
     for k in eachindex(x0)
         low = lims[1][k]
         high = lims[2][k]
@@ -113,9 +173,9 @@ function setup_parameter_optimization(precomputed_states, reports, case::JutulCa
     data[:n_gradient] = 1
     data[:obj_hist] = zeros(0)
 
-    sim = Jutul.Simulator(case)
+    sim = Simulator(case)
     if isnothing(config)
-        config = Jutul.simulator_config(sim; info_level = -1, kwarg...)
+        config = simulator_config(sim; info_level = -1, kwarg...)
     elseif !verbose
         config[:info_level] = -1
         config[:end_report] = false
@@ -124,7 +184,7 @@ function setup_parameter_optimization(precomputed_states, reports, case::JutulCa
     data[:sim_config] = config
 
     if grad_type == :adjoint
-        adj_storage = Jutul.setup_adjoint_storage(model, state0 = state0,
+        adj_storage = setup_adjoint_storage(model, state0 = state0,
                                                    parameters = parameters,
                                                    targets = targets,
                                                    use_sparsity = use_sparsity,
@@ -145,8 +205,8 @@ function setup_parameter_optimization(precomputed_states, reports, case::JutulCa
     data[:x_hash] = hash(x0)
     data[:states] = precomputed_states
     data[:reports] = reports
-    F = x -> Jutul.objective_opt!(x, data, print)
-    dF = (dFdx, x) -> Jutul.gradient_opt!(dFdx, x, data)
-    F_and_dF = (F, dFdx, x) -> Jutul.objective_and_gradient_opt!(F, dFdx, x, data, print)
+    F = x -> objective_opt!(x, data, print)
+    dF = (dFdx, x) -> gradient_opt!(dFdx, x, data)
+    F_and_dF = (F, dFdx, x) -> objective_and_gradient_opt!(F, dFdx, x, data, print)
     return (F! = F, dF! = dF, F_and_dF! = F_and_dF, x0 = x0, limits = lims, data = data)
 end

--- a/src/FlowAD/Types/jutulForce.jl
+++ b/src/FlowAD/Types/jutulForce.jl
@@ -1,21 +1,26 @@
 export jutulForce
 
 struct jutulForce{D, T}
-    irate::Vector{T}
+    irate::T
+    name::Vector{Symbol}
     loc::Vector{NTuple{D, T}}
 end
 
-jutulForce(irate::T, loc::Vector{NTuple{D, T}}) where {D, T} = jutulForce([(-T(1))^(i+1)*irate for i = 1:length(loc)], loc)
+jutulForce(irate::T, loc::Vector{NTuple{D, T}}) = jutulForce(irate::T, vcat(:Injector, [:Producer for i = 1:length(loc)]), loc)
 
 display(f::jutulForce{D, T}) where {D, T} =
     println("$(D)D jutulForce structure with $(length(f.loc)) injection/production wells and rate $(f.irate) m^3/s")
 
-function force(M::jutulModel{D, T}, f::jutulForce{D, T}; ρCO2::T=T(ρCO2)) where {D, T}
+function force(M::jutulModel{D, T}, w::jutulForce{D, T}, tstep::Vector{T}; ρCO2::T=T(ρCO2)) where {D, T}
     model = model_(M)
-    cell_loc = [Int.(round.(f.loc[i] ./ M.d)) for i = 1:length(f.loc)]
-    cell = [sum([(cell_loc[i][d]-1) * prod(M.n[1:d-1]) for d = length(cell_loc[i]):-1:1]) + 1 for i = 1:length(cell_loc)]
-    src  = [SourceTerm(cell[i], f.irate[i] * ρCO2, fractional_flow = [T(f.irate[i] > 0), T(1)-T(f.irate[i] > 0)]) for i = 1:length(f.loc)]
-    return setup_forces(model, sources = src)
+    cell_loc = [Int.(round.(w.loc[i] ./ M.d)) for i = 1:length(w.loc)]
+    Is = [setup_well(CartesianMesh(M), M.K, [cell_loc[i]], name = w.name[i]) for i = 1:length(w.loc)]
+    ctrls = [w.name[i]==:Injector ? InjectorControl(TotalRateTarget(irate * ρCO2 * sum(tstep)), [1.0, 0.0], density = ρCO2) : ProducerControl(BottomHolePressureTarget(50*bar)) for i = 1:length(w.loc)]
+    controls = Dict()
+    for i = 1:length(w.loc)
+        controls[w.name[i]] = ctrls[i]
+    end
+    return Is, controls
 end
 
-==(A::jutulForce{D, T}, B::jutulForce{D, T}) where {D,T} = (A.irate == B.irate && A.loc == B.loc)
+==(A::jutulForce{D, T}, B::jutulForce{D, T}) where {D,T} = (A.irate == B.irate && A.name == B.name && A.loc == B.loc)

--- a/src/FlowAD/Types/jutulForce.jl
+++ b/src/FlowAD/Types/jutulForce.jl
@@ -6,21 +6,9 @@ struct jutulForce{D, T}
     loc::Vector{NTuple{D, T}}
 end
 
-jutulForce(irate::T, loc::Vector{NTuple{D, T}}) = jutulForce(irate::T, vcat(:Injector, [:Producer for i = 1:length(loc)]), loc)
+jutulForce(irate::T, loc::Vector{NTuple{D, T}}) where {D, T}= jutulForce(irate::T, vcat(:Injector, [:Producer for i = 1:length(loc)]), loc)
 
 display(f::jutulForce{D, T}) where {D, T} =
     println("$(D)D jutulForce structure with $(length(f.loc)) injection/production wells and rate $(f.irate) m^3/s")
-
-function force(M::jutulModel{D, T}, w::jutulForce{D, T}, tstep::Vector{T}; ρCO2::T=T(ρCO2)) where {D, T}
-    model = model_(M)
-    cell_loc = [Int.(round.(w.loc[i] ./ M.d)) for i = 1:length(w.loc)]
-    Is = [setup_well(CartesianMesh(M), M.K, [cell_loc[i]], name = w.name[i]) for i = 1:length(w.loc)]
-    ctrls = [w.name[i]==:Injector ? InjectorControl(TotalRateTarget(irate * ρCO2 * sum(tstep)), [1.0, 0.0], density = ρCO2) : ProducerControl(BottomHolePressureTarget(50*bar)) for i = 1:length(w.loc)]
-    controls = Dict()
-    for i = 1:length(w.loc)
-        controls[w.name[i]] = ctrls[i]
-    end
-    return Is, controls
-end
 
 ==(A::jutulForce{D, T}, B::jutulForce{D, T}) where {D,T} = (A.irate == B.irate && A.name == B.name && A.loc == B.loc)

--- a/src/FlowAD/Types/jutulForce.jl
+++ b/src/FlowAD/Types/jutulForce.jl
@@ -6,7 +6,8 @@ struct jutulForce{D, T}
     loc::Vector{NTuple{D, T}}
 end
 
-jutulForce(irate::T, loc::Vector{NTuple{D, T}}) where {D, T}= jutulForce(irate::T, vcat(:Injector, [:Producer for i = 1:length(loc)]), loc)
+jutulForce(irate::T, loc::NTuple{D, T}) where {D, T} = jutulForce(irate, [loc])
+jutulForce(irate::T, loc::Vector{NTuple{D, T}}) where {D, T}= jutulForce(irate, vcat(:Injector, [:Producer for i = 1:length(loc)]), loc)
 
 display(f::jutulForce{D, T}) where {D, T} =
     println("$(D)D jutulForce structure with $(length(f.loc)) injection/production wells and rate $(f.irate) m^3/s")

--- a/src/FlowAD/Types/jutulModel.jl
+++ b/src/FlowAD/Types/jutulModel.jl
@@ -5,9 +5,10 @@ struct jutulModel{D, T}
     d::NTuple{D, T}
     ϕ::Vector{T}
     K::Union{Matrix{T}, T}
+    h::T    # depth of the top grid
 end
 
-function jutulModel(n::NTuple{D, Int64}, d::NTuple{D, T}, ϕ::T, K::Union{Matrix{T}, T}; pad::Bool=true) where {D, T}
+function jutulModel(n::NTuple{D, Int64}, d::NTuple{D, T}, ϕ::T, K::Union{Matrix{T}, T}; h::T=T(0), pad::Bool=true) where {D, T}
     ϕ_full = ϕ * ones(T, n)
     if pad
         ϕ_full[1,:,:] .= 1e8
@@ -16,12 +17,12 @@ function jutulModel(n::NTuple{D, Int64}, d::NTuple{D, T}, ϕ::T, K::Union{Matrix
         ϕ_full[:,:,end] .= 1e8
     end
     ϕ = vec(ϕ_full)
-    return jutulModel(n, d, ϕ, K)
+    return jutulModel(n, d, ϕ, K, h)
 end
 
 display(M::jutulModel{D, T}) where {D, T} =
-    println("$(D)D jutulModel with size $(M.n) and grid spacing $(M.d)")
+    println("$(D)D jutulModel with size $(M.n) and grid spacing $(M.d) at depth $h m")
 
 CartesianMesh(M::jutulModel{D, T}) where {D, T} = CartesianMesh(M.n, M.d .* M.n)
 
-==(A::jutulModel{D, T}, B::jutulModel{D, T}) where {D,T} = (A.n == B.n && A.d == B.d && A.ϕ == B.ϕ && A.K == B.K)
+==(A::jutulModel{D, T}, B::jutulModel{D, T}) where {D,T} = (A.n == B.n && A.d == B.d && A.ϕ == B.ϕ && A.K == B.K && A.h == B.h)

--- a/src/FlowAD/Types/jutulModel.jl
+++ b/src/FlowAD/Types/jutulModel.jl
@@ -3,26 +3,25 @@ export jutulModel, CartesianMesh
 struct jutulModel{D, T}
     n::NTuple{D, Int64}
     d::NTuple{D, T}
-    ϕ::Union{Vector{T}, T}
+    ϕ::Vector{T}
     K::Union{Matrix{T}, T}
+end
+
+function jutulModel(n::NTuple{D, Int64}, d::NTuple{D, T}, ϕ::T, K::Union{Matrix{T}, T}; pad::Bool=true) where {D, T}
+    ϕ_full = ϕ * ones(T, n)
+    if pad
+        ϕ_full[1,:,:] .= 1e8
+        ϕ_full[end,:,:] .= 1e8
+        ϕ_full[:,:,1] .= 1e8
+        ϕ_full[:,:,end] .= 1e8
+    end
+    ϕ = vec(ϕ_full)
+    return jutulModel(n, d, ϕ, K)
 end
 
 display(M::jutulModel{D, T}) where {D, T} =
     println("$(D)D jutulModel with size $(M.n) and grid spacing $(M.d)")
 
 CartesianMesh(M::jutulModel{D, T}) where {D, T} = CartesianMesh(M.n, M.d .* M.n)
-
-function model_(M::jutulModel{D, T}; ρCO2::T=T(ρCO2), ρH2O::T=T(ρH2O)) where {D, T}
-    g = CartesianMesh(M.n, M.d .* M.n)
-    G = discretized_domain_tpfv_flow(tpfv_geometry(g), porosity = M.ϕ, permeability = M.K)
-    model = SimulationModel(G, sys, output_level = :all)
-    p_ref = 1e7 # 100 bar
-    c = [1e-4, 1e-6]./1e5
-    rho_at_ref = [ρCO2, ρH2O]
-    dens = ConstantCompressibilityDensities(p_ref = p_ref, density_ref = rho_at_ref, compressibility = c)
-    replace_variables!(model, PhaseMassDensities = dens)
-    replace_variables!(model, RelativePermeabilities = kr)
-    return model
-end
 
 ==(A::jutulModel{D, T}, B::jutulModel{D, T}) where {D,T} = (A.n == B.n && A.d == B.d && A.ϕ == B.ϕ && A.K == B.K)

--- a/src/FlowAD/Types/jutulModel.jl
+++ b/src/FlowAD/Types/jutulModel.jl
@@ -13,7 +13,7 @@ function jutulModel(n::NTuple{D, Int64}, d::NTuple{D, T}, ϕ::T, K::Union{Matrix
     if pad
         ϕ_full[1,:,:] .= 1e8
         ϕ_full[end,:,:] .= 1e8
-        ϕ_full[:,:,1] .= 1e8
+        ϕ_full[:,:,1] .= ϕ * (h/d[end] + T(1))
         ϕ_full[:,:,end] .= 1e8
     end
     ϕ = vec(ϕ_full)

--- a/src/FlowAD/Types/jutulModel.jl
+++ b/src/FlowAD/Types/jutulModel.jl
@@ -20,6 +20,8 @@ function jutulModel(n::NTuple{D, Int64}, d::NTuple{D, T}, ϕ::T, K::Union{Matrix
     return jutulModel(n, d, ϕ, K, h)
 end
 
+jutulModel(n::NTuple{D, Int64}, d::NTuple{D, T}, ϕ::Vector{T}, K::Union{Matrix{T}, T}) where {D, T} = jutulModel(n, d, ϕ, K, T(0))
+
 display(M::jutulModel{D, T}) where {D, T} =
     println("$(D)D jutulModel with size $(M.n) and grid spacing $(M.d) at depth $(M.h) m")
 

--- a/src/FlowAD/Types/jutulModel.jl
+++ b/src/FlowAD/Types/jutulModel.jl
@@ -21,7 +21,7 @@ function jutulModel(n::NTuple{D, Int64}, d::NTuple{D, T}, ϕ::T, K::Union{Matrix
 end
 
 display(M::jutulModel{D, T}) where {D, T} =
-    println("$(D)D jutulModel with size $(M.n) and grid spacing $(M.d) at depth $h m")
+    println("$(D)D jutulModel with size $(M.n) and grid spacing $(M.d) at depth $(M.h) m")
 
 CartesianMesh(M::jutulModel{D, T}) where {D, T} = CartesianMesh(M.n, M.d .* M.n)
 

--- a/src/FlowAD/Types/jutulSource.jl
+++ b/src/FlowAD/Types/jutulSource.jl
@@ -1,0 +1,15 @@
+export jutulSource
+
+struct jutulSource{D, T}
+    irate::Vector{T}
+    name::Vector{Symbol}
+    loc::Vector{NTuple{D, T}}
+end
+
+jutulSource(irate::T, loc::NTuple{D, T}) where {D, T} = jutulSource(irate, [loc])
+jutulSource(irate::T, loc::Vector{NTuple{D, T}}) where {D, T} = jutulSource([(-T(1))^(i+1)*irate for i = 1:length(loc)], vcat(:Injector, [:Producer for i = 1:length(loc)]), loc)
+
+display(f::jutulSource{D, T}) where {D, T} =
+    println("$(D)D jutulSource structure with $(length(f.loc)) injection/production wells and rate $(f.irate[1]) m^3/s")
+
+==(A::jutulSource{D, T}, B::jutulSource{D, T}) where {D,T} = (A.irate == B.irate && A.name == B.name && A.loc == B.loc)

--- a/src/FlowAD/Types/jutulState.jl
+++ b/src/FlowAD/Types/jutulState.jl
@@ -1,40 +1,54 @@
-export jutulState, jutulStates, dict, Saturations, Pressure
+export jutulState, jutulStates, jutulSimpleState, jutulSimpleStates, dict, Saturations, Pressure
 
 abstract type jutulAllState{T} <: DenseVector{T} end
+abstract type jutulSimpleOrMultiModelStates{T} <: jutulAllState{T} end
+abstract type jutulSimpleOrMultiModelState{T} <: jutulAllState{T} end
 
-struct jutulState{T} <: jutulAllState{T}
+struct jutulState{T} <: jutulSimpleOrMultiModelState{T}
     state::Dict
 end
 
-struct jutulStates{T} <: jutulAllState{T}
+struct jutulStates{T} <: jutulSimpleOrMultiModelStates{T}
     states::Vector{jutulState{T}}
+end
+
+struct jutulSimpleState{T} <: jutulSimpleOrMultiModelState{T}
+    state::Dict
+end
+
+struct jutulSimpleStates{T} <: jutulSimpleOrMultiModelStates{T}
+    states::Vector{jutulSimpleState{T}}
 end
 
 display(state::jutulAllState{T}) where T = println("$(typeof(state))")
 
 jutulState(state::Dict) = jutulState{eltype(state[:Reservoir][:Saturations])}(state)
 jutulStates(states::Vector{Dict{Symbol, T}}) where T = jutulStates{eltype(states[1][:Reservoir][:Saturations])}([jutulState(states[i]) for i = 1:length(states)])
+jutulSimpleState(state::Dict{Symbol, T}) where T = jutulSimpleState{eltype(state[:Saturations])}(state)
+jutulSimpleStates(states::Vector{Dict{Symbol, T}}) where T = jutulSimpleStates{eltype(states[1][:Saturations])}([jutulSimpleState(states[i]) for i = 1:length(states)])
 
 Saturations(state::jutulState) = state.state[:Reservoir][:Saturations][1,:]
 Pressure(state::jutulState) = state.state[:Reservoir][:Pressure]
+Saturations(state::jutulSimpleState) = state.state[:Saturations][1,:]
+Pressure(state::jutulSimpleState) = state.state[:Pressure]
 
-Saturations(state::jutulStates) = vcat([Saturations(state.states[i]) for i = 1:get_nt(state)]...)
-Pressure(state::jutulStates) = vcat([Pressure(state.states[i]) for i = 1:get_nt(state)]...)
+Saturations(state::jutulSimpleOrMultiModelStates) = vcat([Saturations(state.states[i]) for i = 1:get_nt(state)]...)
+Pressure(state::jutulSimpleOrMultiModelStates) = vcat([Pressure(state.states[i]) for i = 1:get_nt(state)]...)
 
-get_nt(state::jutulStates) = length(state.states)
-get_nn(state::jutulState) = length(Saturations(state))
-get_nn(state::jutulStates) = get_nn(state.states[1])
+get_nt(state::jutulSimpleOrMultiModelStates) = length(state.states)
+get_nn(state::jutulSimpleOrMultiModelState) = length(Saturations(state))
+get_nn(state::jutulSimpleOrMultiModelStates) = get_nn(state.states[1])
 
 ###### turn jutulStates to state dictionary
 
-dict(state::jutulState) = state.state
-dict(state::jutulStates) = [dict(state.states[i]) for i = 1:get_nt(state)]
+dict(state::jutulSimpleOrMultiModelState) = state.state
+dict(state::jutulSimpleOrMultiModelStates) = [dict(state.states[i]) for i = 1:get_nt(state)]
 dict(state::Dict) = state
 
 ###### AbstractVector
 
-length(state::jutulState) = length(Saturations(state)) + length(Pressure(state))
-length(state::jutulStates) = sum([length(state.states[i]) for i = 1:get_nt(state)])
+length(state::jutulSimpleOrMultiModelState) = length(Saturations(state)) + length(Pressure(state))
+length(state::jutulSimpleOrMultiModelStates) = sum([length(state.states[i]) for i = 1:get_nt(state)])
 size(state::jutulAllState) = (length(state),)
 
 vec(state::jutulAllState) = vcat(Saturations(state), Pressure(state))
@@ -50,6 +64,16 @@ function getindex(state::jutulState, i::Int)
     end
 end
 
+function getindex(state::jutulSimpleState, i::Int)
+    if i <= get_nn(state)
+        ## getindex for saturation
+        return state.state[:Saturations][1,i]
+    else
+        ## getindex for pressure
+        return state.state[:Pressure][i-get_nn(state)]
+    end
+end
+
 function setindex!(state::jutulState{T}, v, i::Int) where T
     if i <= get_nn(state)
         ## setindex for saturation
@@ -58,6 +82,17 @@ function setindex!(state::jutulState{T}, v, i::Int) where T
     else
         ## setindex for pressure
         state.state[:Reservoir][:Pressure][i-get_nn(state)] = T(v)
+    end
+end
+
+function setindex!(state::jutulSimpleState{T}, v, i::Int) where T
+    if i <= get_nn(state)
+        ## setindex for saturation
+        state.state[:Saturations][1,i] = T(v)
+        state.state[:Saturations][2,i] = T(1) - T(v)
+    else
+        ## setindex for pressure
+        state.state[:Pressure][i-get_nn(state)] = T(v)
     end
 end
 
@@ -73,6 +108,18 @@ function getindex(states::jutulStates, i::Int)
     end
 end
 
+function getindex(states::jutulSimpleStates, i::Int)
+    idx_t = div(i-1, get_nn(states)) + 1
+    idx_n = mod(i-1, get_nn(states)) + 1
+    if idx_t <= get_nt(states)
+        ## getindex for saturation
+        return states.states[idx_t].state[:Saturations][1,idx_n]
+    else
+        ## getindex for pressure
+        return states.states[idx_t-get_nt(states)].state[:Pressure][idx_n]
+    end
+end
+
 function setindex!(states::jutulStates{T}, v, i::Int) where T
     idx_t = div(i-1, get_nn(states)) + 1
     idx_n = mod(i-1, get_nn(states)) + 1
@@ -82,6 +129,18 @@ function setindex!(states::jutulStates{T}, v, i::Int) where T
     else
         ## setindex for pressure
         states.states[idx_t-get_nt(states)].state[:Reservoir][:Pressure][idx_n] = T(v)
+    end
+end
+
+function setindex!(states::jutulSimpleStates{T}, v, i::Int) where T
+    idx_t = div(i-1, get_nn(states)) + 1
+    idx_n = mod(i-1, get_nn(states)) + 1
+    if idx_t <= get_nt(states)
+        ## setindex for saturation
+        states.states[idx_t].state[:Saturations][1,idx_n] = T(v)
+    else
+        ## setindex for pressure
+        states.states[idx_t-get_nt(states)].state[:Pressure][idx_n] = T(v)
     end
 end
 
@@ -104,6 +163,14 @@ function (states::jutulState{T})(x::AbstractArray) where T
     return states_
 end
 
+function (states::jutulSimpleState{T})(x::AbstractArray) where T
+    @assert length(states) == length(x)
+    states_ = deepcopy(states)
+    states_ .= T.(x)
+    states_.state[:Saturations][2,:] = T(1) .- states_.state[:Saturations][1,:]
+    return states_
+end
+
 function (states::jutulStates{T})(x::AbstractArray) where T
     @assert length(states) == length(x)
     states_ = deepcopy(states)
@@ -112,6 +179,24 @@ function (states::jutulStates{T})(x::AbstractArray) where T
         states_.states[i].state[:Reservoir][:Saturations][2,:] = T(1) .- states_.states[i].state[:Reservoir][:Saturations][1,:]
     end
     return states_
+end
+
+function (states::jutulSimpleStates{T})(x::AbstractArray) where T
+    @assert length(states) == length(x)
+    states_ = deepcopy(states)
+    states_ .= T.(x)
+    for i = 1:get_nt(states)
+        states_.states[i].state[:Saturations][2,:] = T(1) .- states_.states[i].state[:Saturations][1,:]
+    end
+    return states_
+end
+
+function jutulSimpleState(M::jutulModel{D, T}; ρCO2::T=T(ρCO2), ρH2O::T=T(ρH2O), g::T=T(10.0)) where {D, T}
+    ## default state at time 0 with all water
+    Z = repeat((1:M.n[end])*M.d[end], inner = prod(M.n[1:2]))
+    p0 = ρH2O * g * (Z .+ M.h) # rho * g * h
+    state0 = setup_state(simple_model(M; ρCO2=ρCO2, ρH2O=ρH2O), Pressure = p0, Saturations = [0.0, 1.0])
+    return jutulSimpleState(state0)
 end
 
 for op in [:+, :-, :*, :/]
@@ -126,7 +211,11 @@ function check_valid_state(states::jutulState{T}) where T
     @assert all(isapprox.(sum(states.state[:Reservoir][:Saturations], dims=1),1; rtol=sqrt(eps(T))))
 end
 
-function check_valid_state(states::jutulStates{T}) where T
+function check_valid_state(states::jutulSimpleState{T}) where T
+    @assert all(isapprox.(sum(states.state[:Saturations], dims=1),1; rtol=sqrt(eps(T))))
+end
+
+function check_valid_state(states::jutulSimpleOrMultiModelStates{T}) where T
     for i = 1:get_nt(states)
         check_valid_state(states.states[i])
     end

--- a/src/FlowAD/Types/jutulState.jl
+++ b/src/FlowAD/Types/jutulState.jl
@@ -85,6 +85,8 @@ function setindex!(states::jutulStates{T}, v, i::Int) where T
     end
 end
 
+getindex(state::jutulAllState, i...) = getindex(vec(state), i...)
+
 firstindex(A::jutulAllState) = 1
 lastindex(A::jutulAllState) = length(A)
 

--- a/src/FlowAD/Types/jutulState.jl
+++ b/src/FlowAD/Types/jutulState.jl
@@ -1,14 +1,9 @@
-export jutulState, jutulStates, dict
+export jutulState, jutulStates, dict, Saturations, Pressure
 
 abstract type jutulAllState{T} <: DenseVector{T} end
 
 struct jutulState{T} <: jutulAllState{T}
-    PhaseMassMobilities::Matrix{T}
-    PhaseMassDensities::Matrix{T}
-    RelativePermeabilities::Matrix{T}
-    Saturations::Vector{T}
-    Pressure::Vector{T}
-    TotalMasses::Matrix{T}
+    state::Dict
 end
 
 struct jutulStates{T} <: jutulAllState{T}
@@ -17,85 +12,76 @@ end
 
 display(state::jutulAllState{T}) where T = println("$(typeof(state))")
 
-jutulState(state::Dict{Symbol, T}) where T =
-    jutulState(state[:Reservoir][:PhaseMassMobilities], state[:Reservoir][:PhaseMassDensities], state[:Reservoir][:RelativePermeabilities], 
-    state[:Reservoir][:Saturations][1,:], state[:Reservoir][:Pressure], state[:Reservoir][:TotalMasses])
+jutulState(state::Dict) = jutulState{eltype(state[:Reservoir][:Saturations])}(state)
+jutulStates(states::Vector{Dict{Symbol, T}}) where T = jutulStates{eltype(states[1][:Reservoir][:Saturations])}([jutulState(states[i]) for i = 1:length(states)])
 
-jutulStates(states::Vector{Dict{Symbol, T}}) where T = jutulStates([jutulState(states[i]) for i = 1:length(states)])
+Saturations(state::jutulState) = state.state[:Reservoir][:Saturations][1,:]
+Pressure(state::jutulState) = state.state[:Reservoir][:Pressure]
 
-function jutulState(M::jutulModel{D, T}; ρCO2::T=T(ρCO2), ρH2O::T=T(ρH2O), g::T=T(10.0)) where {D, T}
-    ## default state at time 0 with all water
-    Z = repeat((1:M.n[end])*M.d[end], inner = prod(M.n[1:2]))
-    p0 = ρH2O * g * Z # rho * g * h
-    state0 = setup_state(model_(M; ρCO2=ρCO2, ρH2O=ρH2O), Pressure = p0, Saturations = [0.0, 1.0])
-    return jutulState(state0)
-end
+Saturations(state::jutulStates) = vcat([Saturations(state.states[i]) for i = 1:get_nt(state)]...)
+Pressure(state::jutulStates) = vcat([Pressure(state.states[i]) for i = 1:get_nt(state)]...)
 
 get_nt(state::jutulStates) = length(state.states)
-get_nn(state::jutulState) = length(state.Saturations)
+get_nn(state::jutulState) = length(Saturations(state))
 get_nn(state::jutulStates) = get_nn(state.states[1])
 
 ###### turn jutulStates to state dictionary
 
-function dict(state::jutulState{T}) where T
-    dict_ = Dict(fieldnames(typeof(state)) .=> getfield.(Ref(state), fieldnames(typeof(state))))
-    dict_[:Saturations] = hcat(dict_[:Saturations], T(1) .- dict_[:Saturations])'
-    return dict_
-end
-
-dict(state::jutulStates{T}) where T = [dict(state.states[i]) for i = 1:get_nt(state)]
+dict(state::jutulState) = state.state
+dict(state::jutulStates) = [dict(state.states[i]) for i = 1:get_nt(state)]
+dict(state::Dict) = state
 
 ###### AbstractVector
 
-length(state::jutulState) = length(state.Saturations) + length(state.Pressure)
+length(state::jutulState) = length(Saturations(state)) + length(Pressure(state))
 length(state::jutulStates) = sum([length(state.states[i]) for i = 1:get_nt(state)])
 size(state::jutulAllState) = (length(state),)
 
-vec(state::jutulStates) = vcat(vcat([state.states[i].Saturations for i = 1:get_nt(state)]...), vcat([state.states[i].Pressure for i = 1:get_nt(state)]...))
-vec(state::jutulState) = vcat(state.Saturations, state.Pressure)
+vec(state::jutulAllState) = vcat(Saturations(state), Pressure(state))
 
 IndexStyle(::jutulAllState) = IndexLinear()
 function getindex(state::jutulState, i::Int)
     if i <= get_nn(state)
         ## getindex for saturation
-        return state.Saturations[i]
+        return state.state[:Reservoir][:Saturations][1,i]
     else
         ## getindex for pressure
-        return state.Pressure[i-get_nn(state)]
+        return state.state[:Reservoir][:Pressure][i-get_nn(state)]
     end
 end
 
-function getindex(state::jutulStates, i::Int)
-    idx_t = div(i-1, get_nn(state)) + 1
-    idx_n = mod(i-1, get_nn(state)) + 1
-    if idx_t <= get_nt(state)
-        ## getindex for saturation
-        return state.states[idx_t].Saturations[idx_n]
-    else
-        ## getindex for pressure
-        return state.states[idx_t-get_nt(state)].Pressure[idx_n]
-    end
-end
-
-function setindex!(state::jutulState, v, i::Int)
+function setindex!(state::jutulState{T}, v, i::Int) where T
     if i <= get_nn(state)
         ## setindex for saturation
-        state.Saturations[i] = v
+        state.state[:Reservoir][:Saturations][1,i] = T(v)
+        state.state[:Reservoir][:Saturations][2,i] = T(1) - T(v)
     else
         ## setindex for pressure
-        state.Pressure[i-get_nn(state)] = v
+        state.state[:Reservoir][:Pressure][i-get_nn(state)] = T(v)
     end
 end
 
-function setindex!(state::jutulStates, v, i::Int)
-    idx_t = div(i-1, get_nn(state)) + 1
-    idx_n = mod(i-1, get_nn(state)) + 1
-    if idx_t <= get_nt(state)
+function getindex(states::jutulStates, i::Int)
+    idx_t = div(i-1, get_nn(states)) + 1
+    idx_n = mod(i-1, get_nn(states)) + 1
+    if idx_t <= get_nt(states)
+        ## getindex for saturation
+        return states.states[idx_t].state[:Reservoir][:Saturations][1,idx_n]
+    else
+        ## getindex for pressure
+        return states.states[idx_t-get_nt(states)].state[:Reservoir][:Pressure][idx_n]
+    end
+end
+
+function setindex!(states::jutulStates{T}, v, i::Int) where T
+    idx_t = div(i-1, get_nn(states)) + 1
+    idx_n = mod(i-1, get_nn(states)) + 1
+    if idx_t <= get_nt(states)
         ## setindex for saturation
-        state.states[idx_t].Saturations[idx_n] = v
+        states.states[idx_t].state[:Reservoir][:Saturations][1,idx_n] = T(v)
     else
         ## setindex for pressure
-        state.states[idx_t-get_nt(state)].Pressure[idx_n] = v
+        states.states[idx_t-get_nt(states)].state[:Reservoir][:Pressure][idx_n] = T(v)
     end
 end
 
@@ -108,10 +94,21 @@ dot(A::jutulAllState, B::jutulAllState) = dot(vec(A), vec(B))
 dot(A::jutulAllState, B::AbstractArray) = dot(vec(A), vec(B))
 dot(A::AbstractArray, B::jutulAllState) = dot(vec(A), vec(B))
 
-function (states::jutulAllState)(x::AbstractArray)
+function (states::jutulState{T})(x::AbstractArray) where T
     @assert length(states) == length(x)
     states_ = deepcopy(states)
-    states_ .= x
+    states_ .= T.(x)
+    states_.state[:Reservoir][:Saturations][2,:] = T(1) .- states_.state[:Reservoir][:Saturations][1,:]
+    return states_
+end
+
+function (states::jutulStates{T})(x::AbstractArray) where T
+    @assert length(states) == length(x)
+    states_ = deepcopy(states)
+    states_ .= T.(x)
+    for i = 1:get_nt(states)
+        states_.states[i].state[:Reservoir][:Saturations][2,:] = T(1) .- states_.states[i].state[:Reservoir][:Saturations][1,:]
+    end
     return states_
 end
 
@@ -122,3 +119,13 @@ for op in [:+, :-, :*, :/]
 end
 
 ==(A::jutulAllState{T}, B::jutulAllState{T}) where {T} = vec(A) == vec(B)
+
+function check_valid_state(states::jutulState{T}) where T
+    @assert all(sum(states.state[:Reservoir][:Saturations], dims=1) .== 1)
+end
+
+function check_valid_state(states::jutulStates{T}) where T
+    for i = 1:get_nt(states)
+        check_valid_state(states.states[i])
+    end
+end

--- a/src/FlowAD/Types/jutulState.jl
+++ b/src/FlowAD/Types/jutulState.jl
@@ -123,7 +123,7 @@ end
 ==(A::jutulAllState{T}, B::jutulAllState{T}) where {T} = vec(A) == vec(B)
 
 function check_valid_state(states::jutulState{T}) where T
-    @assert all(sum(states.state[:Reservoir][:Saturations], dims=1) .== 1)
+    @assert all(isapprox.(sum(states.state[:Reservoir][:Saturations], dims=1),1; rtol=sqrt(eps(T))))
 end
 
 function check_valid_state(states::jutulStates{T}) where T

--- a/src/FlowAD/Types/jutulState.jl
+++ b/src/FlowAD/Types/jutulState.jl
@@ -18,8 +18,8 @@ end
 display(state::jutulAllState{T}) where T = println("$(typeof(state))")
 
 jutulState(state::Dict{Symbol, T}) where T =
-    jutulState(state[:PhaseMassMobilities], state[:PhaseMassDensities], state[:RelativePermeabilities], 
-    state[:Saturations][1,:], state[:Pressure], state[:TotalMasses])
+    jutulState(state[:Reservoir][:PhaseMassMobilities], state[:Reservoir][:PhaseMassDensities], state[:Reservoir][:RelativePermeabilities], 
+    state[:Reservoir][:Saturations][1,:], state[:Reservoir][:Pressure], state[:Reservoir][:TotalMasses])
 
 jutulStates(states::Vector{Dict{Symbol, T}}) where T = jutulStates([jutulState(states[i]) for i = 1:length(states)])
 

--- a/src/FlowAD/Types/type_utils.jl
+++ b/src/FlowAD/Types/type_utils.jl
@@ -23,7 +23,7 @@ function setup_well_model(M::jutulModel{D, T}, f::jutulForce{D, T}, tstep::Vecto
     ### set up model, parameters
     sys = ImmiscibleSystem((VaporPhase(), AqueousPhase()), reference_densities = [ρH2O, ρCO2])
     domain = discretized_domain_tpfv_flow(tpfv_geometry(CartesianMesh(M)), porosity = M.ϕ, permeability = M.K)
-    model, parameters = setup_reservoir_model(domain, sys, wells = Is)
+    model, parameters = setup_reservoir_model(domain, sys, wells = Is; backend=:csr)
     select_output_variables!(model.models.Reservoir, :all)
     ρ = ConstantCompressibilityDensities(p_ref = 150*bar, density_ref = [ρCO2, ρH2O], compressibility = [1e-4/bar, 1e-6/bar])
     replace_variables!(model, PhaseMassDensities = ρ)

--- a/src/FlowAD/Types/type_utils.jl
+++ b/src/FlowAD/Types/type_utils.jl
@@ -23,7 +23,7 @@ function setup_well_model(M::jutulModel{D, T}, f::jutulForce{D, T}, tstep::Vecto
     ### set up model, parameters
     sys = ImmiscibleSystem((VaporPhase(), AqueousPhase()), reference_densities = [ρH2O, ρCO2])
     domain = discretized_domain_tpfv_flow(tpfv_geometry(CartesianMesh(M)), porosity = M.ϕ, permeability = M.K)
-    model, parameters = setup_reservoir_model(domain, sys, wells = Is)
+    model, parameters = setup_reservoir_model(domain, sys, wells = Is; backend = :csr)
     select_output_variables!(model.models.Reservoir, :all)
     ρ = ConstantCompressibilityDensities(p_ref = 150*bar, density_ref = [ρCO2, ρH2O], compressibility = [1e-4/bar, 1e-6/bar])
     replace_variables!(model, PhaseMassDensities = ρ)

--- a/src/FlowAD/Types/type_utils.jl
+++ b/src/FlowAD/Types/type_utils.jl
@@ -38,8 +38,8 @@ function setup_well_model(M::jutulModel{D, T}, f::jutulForce{D, T}, tstep::Vecto
 
     ### initial state
     Z = repeat((1:M.n[end])*M.d[end], inner = prod(M.n[1:2]))
-    p0 = ρH2O * g * Z # rho * g * h
-    state0 = setup_reservoir_state(model, Pressure = 150*bar, Saturations = [0.0, 1.0])
+    p0 = ρH2O * g * (Z .+ M.h) # rho * g * h
+    state0 = setup_reservoir_state(model, Pressure = p0, Saturations = [0.0, 1.0])
 
     return model, parameters, state0, forces
 end

--- a/src/FlowAD/Types/type_utils.jl
+++ b/src/FlowAD/Types/type_utils.jl
@@ -23,7 +23,7 @@ function setup_well_model(M::jutulModel{D, T}, f::jutulForce{D, T}, tstep::Vecto
     ### set up model, parameters
     sys = ImmiscibleSystem((VaporPhase(), AqueousPhase()), reference_densities = [ρH2O, ρCO2])
     domain = discretized_domain_tpfv_flow(tpfv_geometry(CartesianMesh(M)), porosity = M.ϕ, permeability = M.K)
-    model, parameters = setup_reservoir_model(domain, sys, wells = Is; backend = :csr)
+    model, parameters = setup_reservoir_model(domain, sys, wells = Is)
     select_output_variables!(model.models.Reservoir, :all)
     ρ = ConstantCompressibilityDensities(p_ref = 150*bar, density_ref = [ρCO2, ρH2O], compressibility = [1e-4/bar, 1e-6/bar])
     replace_variables!(model, PhaseMassDensities = ρ)

--- a/src/FlowAD/Types/type_utils.jl
+++ b/src/FlowAD/Types/type_utils.jl
@@ -23,7 +23,7 @@ function setup_well_model(M::jutulModel{D, T}, f::jutulForce{D, T}, tstep::Vecto
     ### set up model, parameters
     sys = ImmiscibleSystem((VaporPhase(), AqueousPhase()), reference_densities = [ρH2O, ρCO2])
     domain = discretized_domain_tpfv_flow(tpfv_geometry(CartesianMesh(M)), porosity = M.ϕ, permeability = M.K)
-    model, parameters = setup_reservoir_model(domain, sys, wells = Is; backend=:csr)
+    model, parameters = setup_reservoir_model(domain, sys, wells = Is)
     select_output_variables!(model.models.Reservoir, :all)
     ρ = ConstantCompressibilityDensities(p_ref = 150*bar, density_ref = [ρCO2, ρH2O], compressibility = [1e-4/bar, 1e-6/bar])
     replace_variables!(model, PhaseMassDensities = ρ)

--- a/src/FlowAD/Types/type_utils.jl
+++ b/src/FlowAD/Types/type_utils.jl
@@ -1,0 +1,45 @@
+export setup_well_model
+
+function force(M::jutulModel{D, T}, w::jutulForce{D, T}, tstep::Vector{T};
+    ρCO2::T=T(ρCO2), ρH2O::T=T(ρH2O), g::T=T(10.0)) where {D, T}
+
+    ## set up well information
+    cell_loc = [Int.(round.(w.loc[i] ./ M.d)) for i = 1:length(w.loc)]
+    Is = [setup_well(CartesianMesh(M), M.K, [cell_loc[i]], name = w.name[i]) for i = 1:length(w.loc)]
+    ctrls = [w.name[i]==:Injector ? InjectorControl(TotalRateTarget(w.irate), [1.0, 0.0], density = ρCO2) : ProducerControl(BottomHolePressureTarget(2.0 * ρH2O * g * w.loc[i][3])) for i = 1:length(w.loc)]
+    controls = Dict()
+    for i = 1:length(w.loc)
+        controls[w.name[i]] = ctrls[i]
+    end
+    return Is, controls
+end
+
+function setup_well_model(M::jutulModel{D, T}, f::jutulForce{D, T}, tstep::Vector{T};
+    visCO2::T=T(visCO2), visH2O::T=T(visH2O), ρCO2::T=T(ρCO2), ρH2O::T=T(ρH2O), g::T=T(10.0)) where {D, T}
+
+    ### set up well controls
+    Is, controls = force(M, f, tstep; ρCO2=ρCO2, ρH2O=ρH2O, g=g)    
+
+    ### set up model, parameters
+    sys = ImmiscibleSystem((VaporPhase(), AqueousPhase()), reference_densities = [ρH2O, ρCO2])
+    domain = discretized_domain_tpfv_flow(tpfv_geometry(CartesianMesh(M)), porosity = M.ϕ, permeability = M.K)
+    model, parameters = setup_reservoir_model(domain, sys, wells = Is)
+    select_output_variables!(model.models.Reservoir, :all)
+    ρ = ConstantCompressibilityDensities(p_ref = 150*bar, density_ref = [ρCO2, ρH2O], compressibility = [1e-4/bar, 1e-6/bar])
+    replace_variables!(model, PhaseMassDensities = ρ)
+    replace_variables!(model, PhaseViscosities = vcat(visCO2 * ones(prod(M.n))', visH2O * ones(prod(M.n))'))
+    replace_variables!(model, RelativePermeabilities = BrooksCoreyRelPerm(sys, [2.0, 2.0], [0.1, 0.1], 1.0))
+    for x ∈ keys(model.models)
+        Jutul.select_output_variables!(model.models[x], :all)
+    end
+
+    ### forces
+    forces = setup_reservoir_forces(model, control = controls)
+
+    ### initial state
+    Z = repeat((1:M.n[end])*M.d[end], inner = prod(M.n[1:2]))
+    p0 = ρH2O * g * Z # rho * g * h
+    state0 = setup_reservoir_state(model, Pressure = 150*bar, Saturations = [0.0, 1.0])
+
+    return model, parameters, state0, forces
+end

--- a/src/JutulDarcyAD.jl
+++ b/src/JutulDarcyAD.jl
@@ -12,6 +12,8 @@ module JutulDarcyAD
     using ChainRulesCore
     import Jutul: JutulGeometry, get_facepos, compute_face_trans, compute_half_face_trans, expand_perm
     import Jutul: SimulationModel, select_output_variables!
+    import Jutul: optimization_targets, variable_mapper, optimization_limits, print_parameter_optimization_config
+    import Jutul: objective_opt!, gradient_opt!, objective_and_gradient_opt!
     import Base: +, -, *, /, ==
     import Base: display, length, size, getindex, setindex!, IndexStyle, vec, firstindex, lastindex
     import LinearAlgebra: norm, dot

--- a/src/JutulDarcyAD.jl
+++ b/src/JutulDarcyAD.jl
@@ -11,7 +11,7 @@ module JutulDarcyAD
     using Flux
     using ChainRulesCore
     import Jutul: JutulGeometry, get_facepos, compute_face_trans, compute_half_face_trans, expand_perm
-    import Jutul: SimulationModel
+    import Jutul: SimulationModel, select_output_variables!
     import Base: +, -, *, /, ==
     import Base: display, length, size, getindex, setindex!, IndexStyle, vec, firstindex, lastindex
     import LinearAlgebra: norm, dot
@@ -27,7 +27,6 @@ module JutulDarcyAD
     const Darcy = 9.869232667160130e-13
     const md = Darcy * 1e-3
     
-    const sys = ImmiscibleSystem((VaporPhase(), AqueousPhase()))
     const day = 24*3600.0
 
     include("PropertyConversion/PropertyConversion.jl")

--- a/src/JutulDarcyAD.jl
+++ b/src/JutulDarcyAD.jl
@@ -21,8 +21,9 @@ module JutulDarcyAD
 
     visCO2 = 1e-4
     visH2O = 1e-3
-    ρCO2 = 501.9
-    ρH2O = 1053.0
+    ρCO2 = 7e2
+    ρH2O = 1e3
+    bar = 1e5
 
     const Darcy = 9.869232667160130e-13
     const md = Darcy * 1e-3

--- a/src/PropertyConversion/PropertyConversion.jl
+++ b/src/PropertyConversion/PropertyConversion.jl
@@ -1,6 +1,6 @@
 export TransToK, KtoTrans, K1to3
 
-K1to3(Kx::AbstractArray{T}) where T = vcat(vec(Kx)', vec(Kx)', vec(Kx)')
+K1to3(Kx::AbstractArray{T}; kvoverkh::T=T(1)) where T = vcat(vec(Kx)', vec(Kx)', kvoverkh * vec(Kx)')
 
 function TransToK(g::CartesianMesh, Trans::AbstractVector{T}) where T<:Number
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@ using Test
 using Jutul
 using JutulDarcyAD
 using Flux
-using MultiComponentFlash
 using Printf
 using Random
 using LinearAlgebra

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,5 +17,6 @@ include("test_conversion.jl")
 
 include("test_jutulState.jl")
 include("test_jutulForce.jl")
+include("test_jutulSource.jl")
 include("test_jutulModel.jl")
 include("test_jutulModeling.jl")

--- a/test/test_gradient.jl
+++ b/test/test_gradient.jl
@@ -13,7 +13,7 @@ misfit(x0) = 0.5 * norm(S(x0, q) - states).^2
 g = gradient(()->misfit(x0), Flux.params(x0))
 
 dx = randn(MersenneTwister(2023), length(x0))
-dx = dx/norm(dx) * norm(x0)/6.0
+dx = dx/norm(dx) * norm(x0)/5.0
 
 @testset "Taylor-series gradient test of jutulModeling" begin
     grad_test(misfit, x0, dx, g[x0])

--- a/test/test_gradient.jl
+++ b/test/test_gradient.jl
@@ -1,4 +1,4 @@
-model, model0, q, tstep = test_config()
+model, model0, q, init_state, tstep = test_config();
 
 ## set up modeling operator
 S = jutulModeling(model0, tstep)
@@ -9,11 +9,11 @@ x0 = log.(KtoTrans(CartesianMesh(model0), model0.K))
 
 states = S(x, q)
 
-dx = rand(length(x0))
-dx = dx/norm(dx) * norm(x0)/10
-
 misfit(x0) = 0.5 * norm(S(x0, q) - states).^2
 g = gradient(()->misfit(x0), Flux.params(x0))
+
+dx = randn(MersenneTwister(2023), length(x0))
+dx = dx/norm(dx) * norm(x0)/50.0
 
 @testset "Taylor-series gradient test of jutulModeling" begin
     grad_test(misfit, x0, dx, g[x0])

--- a/test/test_gradient.jl
+++ b/test/test_gradient.jl
@@ -13,7 +13,7 @@ misfit(x0) = 0.5 * norm(S(x0, q) - states).^2
 g = gradient(()->misfit(x0), Flux.params(x0))
 
 dx = randn(MersenneTwister(2023), length(x0))
-dx = dx/norm(dx) * norm(x0)/50.0
+dx = dx/norm(dx) * norm(x0)/6.0
 
 @testset "Taylor-series gradient test of jutulModeling" begin
     grad_test(misfit, x0, dx, g[x0])

--- a/test/test_gradient.jl
+++ b/test/test_gradient.jl
@@ -1,4 +1,4 @@
-model, model0, q, init_state, tstep = test_config();
+model, model0, q, q1, init_state, init_state1, tstep = test_config();
 
 ## set up modeling operator
 S = jutulModeling(model0, tstep)
@@ -15,6 +15,15 @@ g = gradient(()->misfit(x0), Flux.params(x0))
 dx = randn(MersenneTwister(2023), length(x0))
 dx = dx/norm(dx) * norm(x0)/5.0
 
-@testset "Taylor-series gradient test of jutulModeling" begin
+@testset "Taylor-series gradient test of jutulModeling with wells" begin
     grad_test(misfit, x0, dx, g[x0])
+end
+
+states1 = S(x, q1)
+
+misfit1(x0) = 0.5 * norm(S(x0, q1) - states1).^2
+g1 = gradient(()->misfit1(x0), Flux.params(x0))
+
+@testset "Taylor-series gradient test of simple jutulModeling" begin
+    grad_test(misfit1, x0, dx/1.5, g1[x0])
 end

--- a/test/test_jutulForce.jl
+++ b/test/test_jutulForce.jl
@@ -5,6 +5,11 @@
     prod_loc = (28, 1, 9) .* d
     irate = rand()
     q = jutulForce(irate, [inj_loc, prod_loc])
-    q1 = jutulForce([irate, -irate], [inj_loc, prod_loc])
-    @test q == q1
+    q1 = jutulForce(irate, [inj_loc])
+
+    @test q != q1
+    @test q.irate == q1.irate
+    @test q.loc[1] == q1.loc[1]
+    @test q.name[1] == q1.name[1]
+    @test q.name[2] == :Producer
 end

--- a/test/test_jutulModel.jl
+++ b/test/test_jutulModel.jl
@@ -5,13 +5,13 @@
     d = 10 .* (rand(), rand(), rand())
     K = 200 * rand() * md * ones(n)
     ϕ = rand()
-    model = jutulModel(n, d, ϕ, K1to3(K))
+    model = jutulModel(n, d, ϕ, K1to3(K); pad=false)
 
     @test model.n == n
     @test model.d == d
-    @test model.ϕ == ϕ
+    @test all(model.ϕ .== ϕ)
     @test model.K == K1to3(K)
 
-    model1 = jutulModel(n, d, ϕ, K1to3(K))
+    model1 = jutulModel(n, d, ϕ, K1to3(K); pad=false)
     @test model1 == model
 end

--- a/test/test_jutulModeling.jl
+++ b/test/test_jutulModeling.jl
@@ -1,4 +1,4 @@
-model, model0, q, init_state, tstep = test_config();
+model, model0, q, q1, init_state, init_state1, tstep = test_config();
 
 ## set up modeling operator
 S = jutulModeling(model, tstep)
@@ -7,11 +7,19 @@ S = jutulModeling(model, tstep)
 x = log.(KtoTrans(CartesianMesh(model), model.K))
 x0 = log.(KtoTrans(CartesianMesh(model0), model0.K))
 
-states = S(x, q)
-
-@testset "Test mass conservation" begin
+@testset "Test mass conservation for well modeling" begin
+    states = S(x, q)
     for i = 1:length(states.states)
         exist_co2 = sum(Saturations(states.states[i]) .* states.states[i].state[:Reservoir][:PhaseMassDensities][1,:] .* model.ϕ) * prod(model.d)
+        inj_co2 = JutulDarcyAD.ρCO2 * q.irate * JutulDarcyAD.day * sum(tstep[1:i])
+        @test isapprox(exist_co2, inj_co2) rtol=1e-3
+    end
+end
+
+@testset "Test mass conservation for simple modeling" begin
+    states = S(x, q1)
+    for i = 1:length(states.states)
+        exist_co2 = sum(Saturations(states.states[i]) .* states.states[i].state[:PhaseMassDensities][1,:] .* model.ϕ) * prod(model.d)
         inj_co2 = JutulDarcyAD.ρCO2 * q.irate * JutulDarcyAD.day * sum(tstep[1:i])
         @test isapprox(exist_co2, inj_co2) rtol=1e-3
     end

--- a/test/test_jutulModeling.jl
+++ b/test/test_jutulModeling.jl
@@ -1,4 +1,4 @@
-model, model0, q, tstep = test_config()
+model, model0, q, init_state, tstep = test_config();
 
 ## set up modeling operator
 S = jutulModeling(model, tstep)
@@ -11,8 +11,8 @@ states = S(x, q)
 
 @testset "Test mass conservation" begin
     for i = 1:length(states.states)
-        exist_co2 = sum(states.states[i].Saturations .* states.states[i].PhaseMassDensities[1,:]) * prod(model.d) * model.ϕ
-        inj_co2 = JutulDarcyAD.ρCO2 * q.irate[1] * JutulDarcyAD.day * sum(tstep[1:i])
-        @test isapprox(exist_co2, inj_co2) rtol=2e-2
+        exist_co2 = sum(Saturations(states.states[i]) .* states.states[i].state[:Reservoir][:PhaseMassDensities][1,:] .* model.ϕ) * prod(model.d)
+        inj_co2 = JutulDarcyAD.ρCO2 * q.irate * JutulDarcyAD.day * sum(tstep[1:i])
+        @test isapprox(exist_co2, inj_co2) rtol=1e-3
     end
 end

--- a/test/test_jutulSource.jl
+++ b/test/test_jutulSource.jl
@@ -1,0 +1,15 @@
+@testset "Test jutulSource" begin
+    
+    d = (1.0, 20.0, 3.0)
+    inj_loc = (3, 1, 9) .* d
+    prod_loc = (28, 1, 9) .* d
+    irate = rand()
+    q = jutulForce(irate, [inj_loc, prod_loc])
+    q1 = jutulForce(irate, [inj_loc])
+
+    @test q != q1
+    @test q.irate == q1.irate
+    @test q.loc[1] == q1.loc[1]
+    @test q.name[1] == q1.name[1]
+    @test q.name[2] == :Producer
+end

--- a/test/test_jutulState.jl
+++ b/test/test_jutulState.jl
@@ -1,4 +1,4 @@
-model, model0, q, init_state, tstep = test_config();
+model, model0, q, q1, init_state, init_state_simple, tstep = test_config();
 
 @testset "Test jutulState" begin
     @info "length, size"

--- a/test/test_jutulState.jl
+++ b/test/test_jutulState.jl
@@ -1,4 +1,4 @@
-model, init_state = setup_model_state()
+model, model0, q, init_state, tstep = test_config();
 
 @testset "Test jutulState" begin
     @info "length, size"
@@ -18,4 +18,12 @@ model, init_state = setup_model_state()
     @test init_state1 != init_state
     init_state[1] = 0.2
     @test init_state1 == init_state
+
+    @info "test dict"
+    dict(init_state) == init_state.state
+
+    @info "test translation"
+    half_init_state = init_state(vec(init_state) ./ 2)
+    JutulDarcyAD.check_valid_state(half_init_state)
+    @test vec(half_init_state) == 0.5 * vec(init_state)
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -16,11 +16,13 @@ function test_config()
 
     ## injection & production
     inj_loc = (15, 1, 10) .* d
+    prod_loc = (30, 1, 10) .* d
     irate = 5e-3
     q = jutulForce(irate, [inj_loc])
-    state0 = jutulState(setup_well_model(model, q, tstep)[3])
-
-    return model, model0, q, state0, tstep
+    q1 = jutulSource(irate, [inj_loc, prod_loc])
+    state0 = jutulState(JutulDarcyAD.setup_well_model(model, q, tstep)[3])
+    state1 = jutulSimpleState(model)
+    return model, model0, q, q1, state0, state1, tstep
 end
 
 mean(x) = sum(x)/length(x)

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,40 +1,26 @@
-function setup_model_state()
-
-    ## grid size
-    n = (rand(3:5), rand(3:5), rand(3:5))
-    d = 10 .* (rand(), rand(), rand())
+function test_config()
+    n = (30, 1, 15)
+    d = (30.0, 30.0, 30.0)
 
     ## permeability
-    K = 200 * rand() * md * ones(n)
-    ϕ = rand()
-    model = jutulModel(n, d, ϕ, K1to3(K))
-    init_state = jutulState(model)
-    return model, init_state
-
-end
-
-function test_config()
-    n = (10, 1, 10)
-    d = (100.0, 100.0, 100.0)
-
-    K0 = 20 * md * ones(n)
-    K = deepcopy(K0)
-    K[:,:,6:end] .*= 5
+    K0 = 200 * md * ones(n)
     ϕ = 0.25
+    K = deepcopy(K0)
+    K[:,:,1:2:end] .*= 100
 
     model0 = jutulModel(n, d, ϕ, K1to3(K0))
     model = jutulModel(n, d, ϕ, K1to3(K))
 
     ## simulation time steppings
-    tstep = 20 * ones(50)
+    tstep = 50 * ones(10)
 
     ## injection & production
-    inj_loc = (2, 1, 8) .* d
-    prod_loc = (8, 1, 8) .* d
+    inj_loc = (15, 1, 10) .* d
     irate = 5e-3
-    q = jutulForce(irate, [inj_loc, prod_loc])
+    q = jutulForce(irate, [inj_loc])
+    state0 = jutulState(setup_well_model(model, q, tstep)[3])
 
-    return model, model0, q, tstep
+    return model, model0, q, state0, tstep
 end
 
 mean(x) = sum(x)/length(x)


### PR DESCRIPTION
Major restructure of the software deck so that:

1. incorporate reservoir/well modeling
2. pad porosity at the boundary of model
3. irreducible water saturation 10%
4. work with iterative solvers now
5. adjust `rrule` to avoid extra forward evaluation

~~Need to be on `dev` branch of Jutul/JutulDarcy for now (02/08/2023)~~

TO-DO list to finish this PR
1. add back previous simple modeling code (i.e. based on injection/production source, direct solve for small model)

After this PR:
1. derivative w.r.t. source